### PR TITLE
Make FlexOTube require KAS

### DIFF
--- a/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_FlexOTube.cfg
+++ b/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_FlexOTube.cfg
@@ -11,14 +11,14 @@ MODEL
 	model = UmbraSpaceIndustries/MKS/Assets/DockingPort
 }
 cost = 200
-category = Utility
+category = none
 subcategory = 0
 title = MKS Kerbitrail(tm) FlexOTube
 manufacturer = Umbra Space Industries
 description = Expandable, Bendable, Attachable tubes up to 50m long.  Requires KAS.
 attachRules = 1,1,0,0,0
 
-TechRequired = actuators
+TechRequired = Unresearcheable
 entryCost = 50
 
 mass = 0.05
@@ -63,4 +63,10 @@ attachOnEva = true
 }
 
 
+}
+
+@PART[MKS_FlexOTube]:FOR[KolonyTools]:NEEDS[KAS]
+{
+	TechRequired = actuators
+	category = Utility
 }


### PR DESCRIPTION
I suggest setting up the part file so that the FlexOTube is only visible to the player if KAS is installed. The code that enables the part requires Module Manager, of course, but since KAS uses it heavily this isn't actually a new dependency.
