### PR TITLE
Added integrated EL support.

### DIFF
--- a/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_AssemblyPlant.cfg
+++ b/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_AssemblyPlant.cfg
@@ -67,6 +67,13 @@ useResources = true
       requiredResources=ConstructionParts,750
       SurfaceOnly = False
   }
+
+  MODULE {
+      name = ExWorkshop
+      // better-suited than science lab, and has gravity
+      ProductivityFactor = 2
+  }
+
 RESOURCE
 {
 name = ModularParts

--- a/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_ConstructionHub.cfg
+++ b/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_ConstructionHub.cfg
@@ -75,6 +75,13 @@ useResources = true
       outputResources = ModularParts, 20, False,Recyclables,0.1,true
       SurfaceOnly = False
   }
+
+  MODULE {
+      name = ExWorkshop
+      // better-suited than science lab, and has gravity
+      ProductivityFactor = 2
+  }
+
 RESOURCE
 {
 name = Minerals

--- a/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Kerbitat.cfg
+++ b/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Kerbitat.cfg
@@ -77,6 +77,13 @@ useResources = true
       requiredResources=ConstructionParts,750
       SurfaceOnly = False
   }
+
+  MODULE {
+      name = ExWorkshop
+      // like hitchhiker, but with gravity
+      ProductivityFactor = 0.6
+  }
+
 RESOURCE
 {
 name = Oxygen

--- a/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_MachineShop.cfg
+++ b/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_MachineShop.cfg
@@ -67,6 +67,13 @@ useResources = true
       requiredResources=ConstructionParts,750
       SurfaceOnly = False
   }
+
+  MODULE {
+      name = ExWorkshop
+      // better-suited than science lab, and has gravity
+      ProductivityFactor = 2
+  }
+
 RESOURCE
 {
 name = Polymers

--- a/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Workspace.cfg
+++ b/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Workspace.cfg
@@ -38,4 +38,11 @@ model = UmbraSpaceIndustries/MKS/Assets/Workspace
  animSwitch = True
  isOneShot = False
  }
+
+  MODULE {
+      name = ExWorkshop
+      // like science lab, but with gravity
+      ProductivityFactor = 1.0
+  }
+
 }


### PR DESCRIPTION
All MKS spaces now can serve as EL workshops, converting RocketParts into construction (previously, the Workspace was left out). In addition, well-equipped crew spaces are now more productive than the EL default for command pods (0.25×) or crew quarters (0.4×).
