### PR TITLE
Add :FOR[KolonyTools] to RT2 ModuleManager config

### DIFF
--- a/GameData/UmbraSpaceIndustries/MKS_OKS_RT2.cfg
+++ b/GameData/UmbraSpaceIndustries/MKS_OKS_RT2.cfg
@@ -1,4 +1,4 @@
-@PART[MKS_*]:HAS[@MODULE[ModuleCommand]]:NEEDS[RemoteTech2] {
+@PART[MKS_*]:HAS[@MODULE[ModuleCommand]]:FOR[KolonyTools]:NEEDS[RemoteTech2] {
 	MODULE
 	{
 		name = ModuleSPU
@@ -19,7 +19,7 @@
 	}
 }
 
-@PART[OKS_*]:HAS[@MODULE[ModuleCommand]]:NEEDS[RemoteTech2] {
+@PART[OKS_*]:HAS[@MODULE[ModuleCommand]]:FOR[KolonyTools]:NEEDS[RemoteTech2] {
 	MODULE
 	{
 		name = ModuleSPU
@@ -40,7 +40,7 @@
 	}
 }
 
-@PART[*KS_ColonyHub] {
+@PART[*KS_ColonyHub]:AFTER[KolonyTools]:NEEDS[RemoteTech2] {
 	@MODULE[ModuleSPU] {
 		IsRTCommandStation = true
 	}


### PR DESCRIPTION
When I wrote this config for my personal use, I wasn't really thinking about which MM pass it should be in. Now that it's part of the distribution, I think the neighborly thing to do is to assign the patches to a pass that belongs to this mod's plugin.

Also, I got around to testing the IsRTCommandStation patch in this version of the file. If that patch isn't working in the released file, it is here.
