### PR TITLE
Syntax Error in MKS_DockingPort.cfg

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/MKS/Parts/MKS_DockingPort.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MKS/Parts/MKS_DockingPort.cfg
@@ -64,7 +64,7 @@ MODULE
 	referenceAttachNode = dockingNode
 	nodeTransformName = DOCKING
     undockEjectionForce = 0.25
-	minDistanceToReEngage 3.5
+	minDistanceToReEngage = 3.5
     acquireForce = 3.5
     acquireTorque = 3.5
     acquireRange = 3.0


### PR DESCRIPTION
Im pretty sure that this is a syntax error unless for some reason minDistanceToReEngage is a special key.
