### PR TITLE
Added TweakScale to Radial supply tank

### DIFF
--- a/GameData/UmbraSpaceIndustries/Kolonization/MKS/Parts/MKS_RadialTank.cfg
+++ b/GameData/UmbraSpaceIndustries/Kolonization/MKS/Parts/MKS_RadialTank.cfg
@@ -49,6 +49,11 @@ MODULE
   hasGUI = false
 }
 
-
+MODULE
+{
+    name = TweakScale
+    defaultScale = 1.25
+    type = stack
+}
 
 }


### PR DESCRIPTION
Im not sure if you wanted to have this or not. It was just a pain not being able to scale it down for smaller supply crafts. Feel free to reject this if its not something you think you should be able to do
