### PR TITLE
Set AC to respect Kerbal XP setting in all modes.

### DIFF
--- a/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
+++ b/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
@@ -155,11 +155,11 @@ namespace KolonyTools.AC
                     newKerb.experience = GetExperienceNeededFor(KLevel);
                     newKerb.experienceLevel = KLevel;
                 }
-                if (ACLevel == 5 || kerExp == false)
+                if (kerExp == false)
                 {
                     newKerb.experience = 9999;
                     newKerb.experienceLevel = 5;
-                    Debug.Log("KSI :: Level set to 5 - Non-Career Mode default.");
+                    Debug.Log("KSI :: Level set to 5 - Kerbal Experience Off default.");
                 }
 
             }
@@ -269,12 +269,12 @@ namespace KolonyTools.AC
             if (HighLogic.CurrentGame.Mode == Game.Modes.SANDBOX)
             {
                 hasKredits = false;
-                ACLevel = 5;
+                ACLevel = ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.AstronautComplex);
             }
             if (HighLogic.CurrentGame.Mode == Game.Modes.SCIENCE_SANDBOX)
             {
                 hasKredits = false;
-                ACLevel = 5;
+                ACLevel = ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.AstronautComplex);
             }
             if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER)
             {
@@ -331,14 +331,13 @@ namespace KolonyTools.AC
                 // If statements for level options
                 if (kerExp == false)
                 {
-                    GUILayout.Label("Level 5 - Mandatory for Career with no EXP enabled.");
+                    GUILayout.Label("Level 5 - Mandatory with no EXP enabled.");
                 }
                 else
                 {
                     if (ACLevel == 0) { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsZero); }
                     if (ACLevel == 0.5) { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsOne); }
                     if (ACLevel == 1) { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsTwo); }
-                    if (ACLevel == 5) { GUILayout.Label("Level 5 - Mandatory for Sandbox or Science Mode."); }
                 }
                 GUILayout.EndVertical();
 


### PR DESCRIPTION
KSP now has a player-exposed option when starting a game that toggles Kerbal Experience on or off. This option is available in all modes: Sandbox, Science, and Career. KolonyTools does not respect the player's choice for this option, however - on Sandbox and Science modes, it forces the user to hire level 5 kerbals even if Experience is turned on, which is a bit silly as it means the Experience option only actually applies to the veterans.

This fixes that.


----COMMIT MESSAGE:
Once more, with DEVELOP.

Removed game mode checks when determining available levels for recruitment.
Modified GameMode settings to only consider if the mode has credits.

- NB: left ACLevel checking in each game mode even though it's repetitive. It was a tradeoff, but I decided that leaving it in place made it clearer what was changing and that it was intended rather than accidental.