### PR TITLE
Base tags and syntax

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/DemoBlock.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/DemoBlock.cfg
@@ -36,20 +36,20 @@ PART
 		model = UmbraSpaceIndustries/MKS/Assets/Explosives
 	}
 	
-  MODULE
-  {
-	name = USI_ModuleDemolition
-	Menu = Demolish
-	ResourceName = Recyclables
-	Efficiency = .8
-  }
+  	MODULE
+  	{
+		name = USI_ModuleDemolition
+		Menu = Demolish
+		ResourceName = Recyclables
+		Efficiency = .8
+  	}
 
-  MODULE
-  {
-	name = USI_ModuleDemolition
-	Menu = Recycle
-	ResourceName = MaterialKits
-	Efficiency = .5
-  }
+  	MODULE
+  	{
+		name = USI_ModuleDemolition
+		Menu = Recycle
+		ResourceName = MaterialKits
+		Efficiency = .5
+  	}
 
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Duna_Pioneer.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Duna_Pioneer.cfg
@@ -95,7 +95,6 @@ PART
 		multiHop = False
 	}
 
-
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/LightGlobe.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/LightGlobe.cfg
@@ -80,15 +80,14 @@ PART
 
 	CrewCapacity = 0
 	vesselType = Base
-	  MODULE
-	  {
-		  name = ModuleCommand
-		  minimumCrew = 0
-		  RESOURCE
-		  {
-			  name=ElectricCharge
-			  rate = 0.02777778
-		  }
-	  }
-
+	MODULE
+	{
+		name = ModuleCommand
+		minimumCrew = 0
+		RESOURCE
+		{
+			name=ElectricCharge
+			rate = 0.02777778
+		}
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_01A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_01A.cfg
@@ -73,9 +73,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -113,10 +110,7 @@ PART
 		ImpactTransform = ImpactTransform
 		ImpactRange = 7
 		AutoShutdown = true
-		UseSpecialistBonus = false
-		
-		
-		
+		UseSpecialistBonus = false	
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -155,9 +149,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -197,9 +188,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -239,9 +227,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -280,9 +265,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -322,9 +304,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -364,9 +343,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -406,9 +382,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -448,9 +421,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -489,9 +459,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -530,9 +497,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -571,9 +535,6 @@ PART
 		ImpactRange = 7
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02A.cfg
@@ -89,9 +89,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -130,9 +127,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -212,9 +206,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -253,9 +244,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -294,9 +282,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -335,9 +320,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -376,9 +358,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -417,9 +396,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -458,9 +434,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -499,9 +472,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -540,9 +510,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -581,9 +548,6 @@ PART
 		ImpactRange = 5
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03A.cfg
@@ -103,9 +103,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -144,9 +141,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -185,9 +179,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -226,9 +217,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -267,9 +255,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -308,9 +293,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -349,9 +331,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -390,9 +369,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -431,9 +407,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -472,9 +445,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -513,9 +483,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -554,9 +521,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier
@@ -595,9 +559,6 @@ PART
 		ImpactRange = 15
 		AutoShutdown = true
 		UseSpecialistBonus = false
-		
-		
-		
 		EfficiencyBonus = 1
 		GeneratesHeat = true
 		TemperatureModifier

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_AgModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_AgModule.cfg
@@ -181,7 +181,6 @@ PART
 		}
 	}		
 	
-	
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
@@ -237,35 +236,32 @@ PART
 			ResourceName = Machinery
 			Ratio = 500
 		}
-	}	
-		
-    			
-	
-	
+	}
+
 	MODULE
 	{
-        name = ModuleKISItem
-        shortcutKeyAction = drop
-        useName = use
-        usableFromEva = true
-        usableFromContainer = true
-        usableFromPod = true
-        usableFromEditor = true
-        stackable = false
-        volumeOverride = 1000
-        editorItemsCategory = false
-        moveSndPath = KIS/Sounds/itemMove
-        equipable = false
-        equipMode = part
-        equipSlot = Back Pocket
-        equipSkill = 
-        equipRemoveHelmet = false
-        equipMeshName = helmet
-        equipBoneName = helmet01
-        equipPos = (0, 0, 0)
-        equipDir = (0, 0, 0)
-        carriable = true
-        allowAttachOnStatic = false
+        	name = ModuleKISItem
+        	shortcutKeyAction = drop
+        	useName = use
+        	usableFromEva = true
+        	usableFromContainer = true
+        	usableFromPod = true
+        	usableFromEditor = true
+        	stackable = false
+        	volumeOverride = 1000
+        	editorItemsCategory = false
+        	moveSndPath = KIS/Sounds/itemMove
+        	equipable = false
+        	equipMode = part
+        	equipSlot = Back Pocket
+        	equipSkill = 
+        	equipRemoveHelmet = false
+        	equipMeshName = helmet
+        	equipBoneName = helmet01
+        	equipPos = (0, 0, 0)
+        	equipDir = (0, 0, 0)
+        	carriable = true
+        	allowAttachOnStatic = false
 	}
 
 	MODULE
@@ -341,7 +337,6 @@ PART
 		useResources = true    
 	}		
 	
-
 	MODULE
 	{
 		name = MKSModule

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Airlock.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Airlock.cfg
@@ -35,7 +35,6 @@ PART
 	crashTolerance = 15
 	maxTemp = 2000
 	bulkheadProfiles = size1
-
 	crashTolerance = 15
 	breakingForce = 250
 	breakingTorque = 250

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_AnchorHub.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_AnchorHub.cfg
@@ -43,16 +43,16 @@ PART
 
 	CrewCapacity = 0
 	vesselType = Base
-	  MODULE
-	  {
-		  name = ModuleCommand
-		  minimumCrew = 0
-		  RESOURCE
-		  {
-			  name=ElectricCharge
-			  rate = 0.02777778
-		  }
-	  }
+	MODULE
+	{
+		name = ModuleCommand
+		minimumCrew = 0
+		RESOURCE
+		{
+			name=ElectricCharge
+			rate = 0.02777778
+		}
+	}
 
 	MODULE
 	{

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Crusher.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Crusher.cfg
@@ -146,7 +146,6 @@ PART
 		}
 	}
 
-
 	MODULE
 	{
 		name = ModuleEfficiencyPart

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_HabModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_HabModule.cfg
@@ -83,7 +83,6 @@ PART
 		}		
 	}	
 	
-
 	MODULE 
 	{
 		name = ModuleHabitation
@@ -135,28 +134,28 @@ PART
 
 	MODULE
 	{
-        name = ModuleKISItem
-        shortcutKeyAction = drop
-        useName = use
-        usableFromEva = true
-        usableFromContainer = true
-        usableFromPod = true
-        usableFromEditor = true
-        stackable = false
-        volumeOverride = 1000
-        editorItemsCategory = false
-        moveSndPath = KIS/Sounds/itemMove
-        equipable = false
-        equipMode = part
-        equipSlot = Back Pocket
-        equipSkill = 
-        equipRemoveHelmet = false
-        equipMeshName = helmet
-        equipBoneName = helmet01
-        equipPos = (0, 0, 0)
-        equipDir = (0, 0, 0)
-        carriable = true
-        allowAttachOnStatic = false
+        	name = ModuleKISItem
+        	shortcutKeyAction = drop
+        	useName = use
+        	usableFromEva = true
+        	usableFromContainer = true
+        	usableFromPod = true
+        	usableFromEditor = true
+       		stackable = false
+        	volumeOverride = 1000
+        	editorItemsCategory = false
+        	moveSndPath = KIS/Sounds/itemMove
+        	equipable = false
+        	equipMode = part
+        	equipSlot = Back Pocket
+        	equipSkill = 
+        	equipRemoveHelmet = false
+        	equipMeshName = helmet
+        	equipBoneName = helmet01
+        	equipPos = (0, 0, 0)
+        	equipDir = (0, 0, 0)
+        	carriable = true
+        	allowAttachOnStatic = false
 	}
 
 	MODULE

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_MountPoint.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_MountPoint.cfg
@@ -35,7 +35,6 @@ PART
 	crashTolerance = 15
 	maxTemp = 2000 
 	bulkheadProfiles = size1
-
 	crashTolerance = 15
 	breakingForce = 250
 	breakingTorque = 250

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_PowerPack.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_PowerPack.cfg
@@ -36,7 +36,6 @@ PART
 	crashTolerance = 15
 	maxTemp = 2000 
 	bulkheadProfiles = size1
-
 	crashTolerance = 15
 	breakingForce = 250
 	breakingTorque = 250
@@ -47,7 +46,7 @@ PART
 		ConverterName = Generator
 		StartActionName = Start Generator
 		StopActionName = Stop Generator
-		 FillAmount = 0.95		
+		FillAmount = 0.95		
 
 		INPUT_RESOURCE
 		{

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Sifter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Sifter.cfg
@@ -49,7 +49,6 @@ PART
 		moduleType = Shovel
 	}	
 	
-
 	RESOURCE
 	{
 		name = Machinery

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Smelter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Smelter.cfg
@@ -47,7 +47,6 @@ PART
 		ConverterName = Chemicals
 		StartActionName = Start Chemicals
 		StopActionName = Stop Chemicals
-		
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05
@@ -99,8 +98,7 @@ PART
 		name = ModuleResourceConverter_USI
 		ConverterName = Metals
 		StartActionName = Start Metals
-		StopActionName = Stop Metals
-		
+		StopActionName = Stop Metals	
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05
@@ -153,7 +151,6 @@ PART
 		ConverterName = Polymers
 		StartActionName = Start Polymers
 		StopActionName = Stop Polymers
-		
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Workshop.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_Workshop.cfg
@@ -43,28 +43,28 @@ PART
 
 	MODULE
 	{
-        name = ModuleKISItem
-        shortcutKeyAction = drop
-        useName = use
-        usableFromEva = true
-        usableFromContainer = true
-        usableFromPod = true
-        usableFromEditor = true
-        stackable = false
-        volumeOverride = 1000
-        editorItemsCategory = false
-        moveSndPath = KIS/Sounds/itemMove
-        equipable = false
-        equipMode = part
-        equipSlot = Back Pocket
-        equipSkill = 
-        equipRemoveHelmet = false
-        equipMeshName = helmet
-        equipBoneName = helmet01
-        equipPos = (0, 0, 0)
-        equipDir = (0, 0, 0)
-        carriable = true
-        allowAttachOnStatic = false
+        	name = ModuleKISItem
+        	shortcutKeyAction = drop
+        	useName = use
+        	usableFromEva = true
+        	usableFromContainer = true
+        	usableFromPod = true
+        	usableFromEditor = true
+        	stackable = false
+        	volumeOverride = 1000
+        	editorItemsCategory = false
+        	moveSndPath = KIS/Sounds/itemMove
+        	equipable = false
+        	equipMode = part
+        	equipSlot = Back Pocket
+        	equipSkill = 
+        	equipRemoveHelmet = false
+        	equipMeshName = helmet
+        	equipBoneName = helmet01
+        	equipPos = (0, 0, 0)
+        	equipDir = (0, 0, 0)
+        	carriable = true
+        	allowAttachOnStatic = false
 	}
 
 	CrewCapacity = 0
@@ -72,7 +72,6 @@ PART
 	{
 		name = crewCabinInternals
 	}	
-
 
 	MODULE
 	{
@@ -92,11 +91,10 @@ PART
 	{
 		name = MKSModule
 	}
-	
-	
+		
 	MODULE
 	{
-			 name = USI_ModuleRecycleBin
+		name = USI_ModuleRecycleBin
 	}
 
 	MODULE
@@ -104,14 +102,12 @@ PART
 		name = USI_ModuleFieldRepair
 	}
 
-
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
 		ConverterName = MaterialKits
 		StartActionName = Start MaterialKits
 		StopActionName = Stop MaterialKits
-
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05
@@ -169,7 +165,6 @@ PART
 		ConverterName = Machinery
 		StartActionName = Start Machinery
 		StopActionName = Stop Machinery
-
 		UseSpecialistBonus = true
 		SpecialistEfficiencyFactor = 0.2
 		SpecialistBonusBase = 0.05

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Salamander.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Salamander.cfg
@@ -34,7 +34,6 @@ PART
 	breakingForce = 20
 	breakingTorque = 20
 	maxTemp = 2400
-
 	vesselType = Ship
 	CrewCapacity = 2
 	bulkheadProfiles = size2
@@ -53,7 +52,6 @@ PART
 		jettisonForce = 15
 		jettisonDirection = 0 0 1
 	}
-
 
 	MODULE
 	{
@@ -134,7 +132,6 @@ PART
 		ConverterName = Life Support
 		StartActionName = Start Life Support
 		StopActionName = Stop Life Support
-
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_275_Hab.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_275_Hab.cfg
@@ -36,7 +36,6 @@ PART
 	maxTemp = 1200 // = 2900
 	bulkheadProfiles = size1
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_425_Hab.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_425_Hab.cfg
@@ -37,7 +37,6 @@ PART
 	maxTemp = 1200 // = 2900
 	bulkheadProfiles = size1
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture250.cfg
@@ -63,7 +63,6 @@ PART
 		reverseVisibility = true		
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Agriculture375.cfg
@@ -78,7 +78,6 @@ PART
 		attachNodeNames = 125bottom
 	}		
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Airlock.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Airlock.cfg
@@ -48,7 +48,6 @@ PART
 		attachNodeNames = 125
 	}
 
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Akademy.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Akademy.cfg
@@ -78,8 +78,7 @@ PART
 		attachNodeNames = 125bottom
 	}	
 	
-
-MODULE
+	MODULE
 	{
 		name = ModuleScienceContainer
 		reviewActionName = Review Data
@@ -113,16 +112,16 @@ MODULE
 	}
 	
 
-  MODULE
-  {
-      name = ModuleCommand
-      minimumCrew = 0
-      RESOURCE
-      {
-          name=ElectricCharge
-          rate = 0.02777778
-      }
-  }
+  	MODULE
+  	{
+      		name = ModuleCommand
+      		minimumCrew = 0
+      		RESOURCE
+      		{
+          		name=ElectricCharge
+          		rate = 0.02777778
+      		}
+  	}
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_AssemblyPlant.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_AssemblyPlant.cfg
@@ -78,7 +78,7 @@ PART
 		attachNodeNames = 125bottom
 	}	
 	
-MODULE
+	MODULE
 	{
 		name = ModuleScienceContainer
 		reviewActionName = Review Data
@@ -108,16 +108,16 @@ MODULE
 		ProductivityFactor  = 5
 	}
 
-  MODULE
-  {
-      name = ModuleCommand
-      minimumCrew = 0
-      RESOURCE
-      {
-          name=ElectricCharge
-          rate = 0.02777778
-      }
-  }
+  	MODULE
+  	{
+     		name = ModuleCommand
+      		minimumCrew = 0
+      		RESOURCE
+      		{
+         		name=ElectricCharge
+          		rate = 0.02777778
+      		}
+  	}
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Hub250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Hub250.cfg
@@ -77,7 +77,6 @@ PART
 		attachNodeNames = right
 	}
 
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Hub250_Short.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Hub250_Short.cfg
@@ -76,7 +76,6 @@ PART
 		attachNodeNames = right
 	}
 
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kerbitat250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kerbitat250.cfg
@@ -63,7 +63,6 @@ PART
 		reverseVisibility = true		
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kerbitat375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kerbitat375.cfg
@@ -78,7 +78,6 @@ PART
 		attachNodeNames = 125bottom
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kolonist250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kolonist250.cfg
@@ -63,7 +63,6 @@ PART
 		reverseVisibility = true		
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kolonist375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kolonist375.cfg
@@ -78,8 +78,7 @@ PART
 		attachNodeNames = 125bottom
 	}	
 	
-
-MODULE
+	MODULE
 	{
 		name = ModuleScienceContainer
 		reviewActionName = Review Data
@@ -109,16 +108,16 @@ MODULE
 	}
 
 
-  MODULE
-  {
-      name = ModuleCommand
-      minimumCrew = 0
-      RESOURCE
-      {
-          name=ElectricCharge
-          rate = 0.02777778
-      }
-  }
+  	MODULE
+  	{
+      		name = ModuleCommand
+      		minimumCrew = 0
+      		RESOURCE
+      		{
+          		name=ElectricCharge
+          		rate = 0.02777778
+      		}
+  	}
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MedBay250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MedBay250.cfg
@@ -63,7 +63,6 @@ PART
 		reverseVisibility = true		
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MedBay375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MedBay375.cfg
@@ -78,8 +78,7 @@ PART
 		attachNodeNames = 125bottom
 	}	
 	
-
-MODULE
+	MODULE
 	{
 		name = ModuleScienceContainer
 		reviewActionName = Review Data
@@ -107,16 +106,16 @@ MODULE
 		name = ExWorkshop
 		ProductivityFactor  = 5
 	}
-	  MODULE
-	  {
-		  name = ModuleCommand
-		  minimumCrew = 0
-		  RESOURCE
-		  {
-			  name=ElectricCharge
-			  rate = 0.02777778
-		  }
-	  }
+	MODULE
+	{
+		name = ModuleCommand
+		minimumCrew = 0
+		RESOURCE
+		{
+			name=ElectricCharge
+			rate = 0.02777778
+		}
+	}
 	RESOURCE
 	{
 		name = ElectricCharge

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MiniTruss.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MiniTruss.cfg
@@ -18,7 +18,7 @@ PART
 	node_stack_Doughnuttop = 0.0, 1.55, 0.0, 0.0, 1.0, 0.0, 1
 
 	node_stack_125bot      = 0.0, -1.85, 0.0, 0.0, -1.0, 0.0, 1
-    node_stack_Doughnutbot = 0.0, -1.55, 0.0, 0.0, -1.0, 0.0, 1
+    	node_stack_Doughnutbot = 0.0, -1.55, 0.0, 0.0, -1.0, 0.0, 1
 
 	node_stack_top = 0.0, 1.25, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_bottom = 0.0, -1.25, 0.0, 0.0, -1.0, 0.0, 1
@@ -59,7 +59,6 @@ PART
 		attachNodeNames = Doughnutbot
 	}
 
-
 	MODULE
 	{
 		name = ModuleStructuralNode
@@ -79,7 +78,7 @@ PART
 		attachNodeNames = Doughnuttop
 		reverseVisibility = true
 	}
-		MODULE
+	MODULE
 	{
 		name = ModuleStructuralNode
 		rootObject = MountFlushBottom

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MultiHub.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MultiHub.cfg
@@ -130,7 +130,6 @@ PART
 		attachNodeNames = FC4
 	}
 
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MultiTruss.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_MultiTruss.cfg
@@ -26,7 +26,7 @@ PART
 	node_stack_Doughnuttop = 0.0, 2.55, 0.0, 0.0, 1.0, 0.0, 1
 
 	node_stack_125bot      = 0.0, -2.85, 0.0, 0.0, -1.0, 0.0, 1
-    node_stack_Doughnutbot = 0.0, -2.55, 0.0, 0.0, -1.0, 0.0, 1
+    	node_stack_Doughnutbot = 0.0, -2.55, 0.0, 0.0, -1.0, 0.0, 1
 
 	node_stack_top = 0.0, 2.25, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_bottom = 0.0, -2.25, 0.0, 0.0, -1.0, 0.0, 1
@@ -67,7 +67,6 @@ PART
 		attachNodeNames = Doughnutbot
 	}
 
-
 	MODULE
 	{
 		name = ModuleStructuralNode
@@ -87,7 +86,7 @@ PART
 		attachNodeNames = Doughnuttop
 		reverseVisibility = true
 	}
-		MODULE
+	MODULE
 	{
 		name = ModuleStructuralNode
 		rootObject = MountFlushBottom

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_NukeProc.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_NukeProc.cfg
@@ -79,7 +79,7 @@ PART
 		attachNodeNames = 125bottom
 	}	
 	
-MODULE
+	MODULE
 	{
 		name = ModuleScienceContainer
 		reviewActionName = Review Data

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_PDU.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_PDU.cfg
@@ -63,7 +63,6 @@ PART
 		reverseVisibility = true		
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_PioneerLC.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_PioneerLC.cfg
@@ -63,7 +63,6 @@ PART
 		reverseVisibility = true		
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand
@@ -113,9 +112,7 @@ PART
 	MODULE
 	{
 		name = ModulePowerCoupler
-	}		
-		
-	
+	}	
 	
 	MODULE
 	{

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_RecyclingPlant.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_RecyclingPlant.cfg
@@ -78,8 +78,7 @@ PART
 		attachNodeNames = 125bottom
 	}	
 	
-
-MODULE
+	MODULE
 	{
 		name = ModuleScienceContainer
 		reviewActionName = Review Data
@@ -108,16 +107,16 @@ MODULE
 	}
 
 
-  MODULE
-  {
-      name = ModuleCommand
-      minimumCrew = 0
-      RESOURCE
-      {
-          name=ElectricCharge
-          rate = 0.02777778
-      }
-  }
+  	MODULE
+  	{
+      		name = ModuleCommand
+      		minimumCrew = 0
+      		RESOURCE
+      		{
+          		name=ElectricCharge
+          		rate = 0.02777778
+      		}
+  	}
 	MODULE
 	{
 		name = ModulePowerCoupler

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Refinery.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Refinery.cfg
@@ -129,7 +129,6 @@ PART
 		name = ModuleLifeSupport
 	}
 
-
 	//********************************
 	MODULE
 	{

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_RegSifter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_RegSifter.cfg
@@ -112,8 +112,8 @@ PART
       		minimumCrew = 0
       		RESOURCE
       		{
-          	name=ElectricCharge
-         	rate = 0.02777778
+          		name=ElectricCharge
+         		rate = 0.02777778
       		}
   	}
 	MODULE
@@ -233,8 +233,6 @@ PART
 		}
 	}		
 
-
-	
 	RESOURCE
 	{
 		name = Machinery

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Workshop250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Workshop250.cfg
@@ -64,7 +64,6 @@ PART
 		reverseVisibility = true		
 	}	
 	
-	vesselType = Base
 	MODULE
 	{
 		name = ModuleCommand
@@ -107,18 +106,16 @@ PART
 	{
 		name = MKSModule
 	}
-	
-	
+		
 	MODULE
 	{
-			 name = USI_ModuleRecycleBin
+		name = USI_ModuleRecycleBin
 	}
 
 	MODULE
 	{
 		name = USI_ModuleFieldRepair
 	}
-
 
 	MODULE
 	{


### PR DESCRIPTION
Removed the vesseltype = Base line from most parts to allow them to be used on-orbit, and also tidied up some bits of messy or inconsistent syntax in the cfgs.