### PR TITLE
Fix AppLauncher btn for voicey99's file sorting

### DIFF
--- a/Source/KolonyTools/KolonyTools/Kolonization/KolonizationMonitor.cs
+++ b/Source/KolonyTools/KolonyTools/Kolonization/KolonizationMonitor.cs
@@ -59,7 +59,7 @@ namespace KolonyTools
             else
             {
                 var texture = new Texture2D(36, 36, TextureFormat.RGBA32, false);
-                var textureFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Kolony.png");
+                var textureFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Assets/UI/Kolony.png");
                 print("Loading " + textureFile);
                 texture.LoadImage(File.ReadAllBytes(textureFile));
                 this.kolonyButton = ApplicationLauncher.Instance.AddModApplication(GuiOn, GuiOff, null, null, null, null,


### PR DESCRIPTION
If Blizzy toolbar isn't installed then default AppLauncher throws exception trying to load Kolony Manager icon because file was moved.