### PR TITLE
Moved MKS parts out of starting tech node

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_WideLeg.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_WideLeg.cfg
@@ -13,7 +13,7 @@ PART
 	node_stack_top = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 1
 	node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1
 	
-	TechRequired = start
+	TechRequired = landing
 	entryCost = 8100
 	cost = 200
 	category = Ground

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_VBracket.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_VBracket.cfg
@@ -14,7 +14,7 @@ PART
 	node_stack_bottom = 0,-1.65,0, 0,-1,0,2
 	node_stack_top = 0,0,.9,0,0,-1,2
 	
-	TechRequired = start
+	TechRequired = advConstruction
 	entryCost = 8100
 	cost = 200
 	category = Structural


### PR DESCRIPTION
The "Wide landing leg" and "MKS 'Ranger' 2.5m stack adapter" parts were available at the beginning of career mode. This branch moves the leg to landing and the stack adapter to advanced construction.