### PR TITLE
Add mini-truss and multi-truss to KIS.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/KIS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/KIS.cfg
@@ -80,7 +80,7 @@
 	}
 }
 
-@PART[Ranger_AgModule,Ranger_Airlock,Ranger_AuxCon,Ranger_BallHub,Ranger_BatPak,Ranger_CommPak,Ranger_Crusher,Ranger_HabModule,Ranger_HeatPump,Ranger_ISM,Ranger_MiniHab,Ranger_MountPoint,Ranger_PowerPack,Ranger_Sifter,Ranger_Smelter,Ranger_Workshop]:NEEDS[KIS]
+@PART[Ranger_AgModule,Ranger_Airlock,Ranger_AuxCon,Ranger_BallHub,Ranger_BatPak,Ranger_CommPak,Ranger_Crusher,Ranger_HabModule,Ranger_HeatPump,Ranger_ISM,Ranger_MiniHab,Ranger_MountPoint,Ranger_PowerPack,Ranger_Sifter,Ranger_Smelter,Ranger_Workshop,Tundra_MiniTruss,Tundra_MultiTruss]:NEEDS[KIS]
 {
 	MODULE
 	{


### PR DESCRIPTION
Overrides the volume of Tundra_MiniTruss and Tundra_Multitruss and makes them easily carriable.