### PR TITLE
Move automated drills into appropriate CTT categories

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/MKS_CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/MKS_CTT.cfg
@@ -40,17 +40,17 @@
     @TechRequired = longTermHabitation
 }
 
-@PART[MKS_Drill_01]:NEEDS[CommunityTechTree]
+@PART[MKS_Drill_01*]:NEEDS[CommunityTechTree]
 {
     @TechRequired = advScienceTech
 }
 
-@PART[MKS_Drill_02]:NEEDS[CommunityTechTree]
+@PART[MKS_Drill_02*]:NEEDS[CommunityTechTree]
 {
     @TechRequired = advOffworldMining
 }
 
-@PART[MKS_Drill_03]:NEEDS[CommunityTechTree]
+@PART[MKS_Drill_03*]:NEEDS[CommunityTechTree]
 {
     @TechRequired = resourceExploitation
 }


### PR DESCRIPTION
When CTT is installed, the three regular MKS drills are placed into different tech categories, but the drills' automated variants were added later and didn't get patched.  It makes more sense to have the automated drills in the same tech nodes as their non-automated counterparts.  (And if any other drill variants are added in the future, they should get the same treatment, so I've used a wildcard to match them in the patch.)