### PR TITLE
Reduce KIS volume of node helper

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/KIS.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/KIS.cfg
@@ -196,3 +196,14 @@
 		defaultMoveSndPath = KIS/Sounds/itemMove
 	}
 }
+
+@PART[NodeHelper]:NEEDS[KIS]
+{
+	// This part isn't a real spacecraft component and shouldn't take up
+	// space like one.  Should be basically "free" to carry.
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 0.1
+	}
+}


### PR DESCRIPTION
The node helper has a default KIS volume of 2110L based on its model — too big for a 1.25m kontainer, much too big for a kerbal to carry.  But it's really meant as a UI tool, not a physical spacecraft component, so it doesn't make sense for it to take up that much space.  This patch makes KIS treat it as very small so kerbals can carry it, and so it can be manufactured in the field using OSE Workshop without needing a large kontainer.