### PR TITLE
Fix PAL_Gripper.cfg syntax errors

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/PAL_Gripper.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/PAL_Gripper.cfg
@@ -1,7 +1,7 @@
-/Konstruction/
+PART
 {
 	name = PAL_Gripper
-	module = /Konstruction/
+	module = Part
 	author = Roverdude
 	
 rescaleFactor = 1
@@ -26,12 +26,12 @@ category = none
 subcategory = -1
 title = PAL Magnetic Manipulator
 manufacturer = USI - Construction Division
-description = A fully articulated multi-joint manipulator arm with a set of magnetic pads at the end.  Ideal for manipulating /Konstruction/s into position.
+description = A fully articulated multi-joint manipulator arm with a set of magnetic pads at the end.  Ideal for manipulating parts into position.
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,0,0,0
 
-// --- standard /Konstruction/ parameters ---
+// --- standard part parameters ---
 mass = 1.25
 dragModelType = default
 maximum_drag = 0.3


### PR DESCRIPTION
Looks like there was an accidental search-and-replace changing occurrences of "part" to "/Konstruction/" in this file, which prevented the part from appearing in the game.