### PR TITLE
Add LH2 boiloff to Karibou tanks

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Patches/CryoTanks.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Patches/CryoTanks.cfg
@@ -1,0 +1,15 @@
+@PART[KER_Adapter,KER_Tank,KER_WheelBay*]:NEEDS[SimpleBoiloff]
+{
+	MODULE
+	{
+		name = ModuleCryoTank
+		CoolingCost = 0.09
+		CoolingEnabled = False
+		BOILOFFCONFIG
+		{
+			FuelName = LqdHydrogen
+			// in % per hr
+			BoiloffRate = 0.05
+		}
+	}
+}


### PR DESCRIPTION
When the CryoTanks mod is installed, all `LqdHydrogen` tanks should have this module, so that the cryogenic fuel boils off unless the tank is actively cooled.  CryoTanks automatically adds it (along with a fuel switcher) to plain LFO tanks, but it doesn't touch parts that already have fuel switchers, so the Karibou tanks need a patch of their own.

I've used the 0.09EC cooling cost meant for general-purpose fuel tanks — see UmbraSpaceIndustries/USI_Core#99 for the corresponding proposed change to the Kontainer tanks.  But I'll change it to the lower 0.08EC ZBO cooling cost if you prefer.