### PR TITLE
Increase drill costs for balance with stock drills

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_01.cfg
@@ -16,7 +16,7 @@ PART
 	}
 
 	// --- editor parameters ---
-	cost = 250
+	cost = 1112
 	category = Utility
 	subcategory = 0
 	title = MEU-100 Pulse Drill
@@ -26,7 +26,7 @@ PART
 	tags = USI MKS drill MEU pulse resources surface harvester thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water
 
 	TechRequired = advScienceTech
-	entryCost = 125
+	entryCost = 3336
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,0,0,0

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_01A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_01A.cfg
@@ -16,7 +16,7 @@ PART
 	}
 
 	// --- editor parameters ---
-	cost = 250
+	cost = 1223
 	category = Utility
 	subcategory = 0
 	title = MEU-100-A Pulse Drill
@@ -26,7 +26,7 @@ PART
 	tags = USI MKS drill MEU pulse resources surface harvester thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water 
 
 	TechRequired = advScienceTech
-	entryCost = 125
+	entryCost = 3370
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,0,0,0

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02.cfg
@@ -19,7 +19,7 @@ PART
 
 
 	// --- editor parameters ---
-	cost = 1300
+	cost = 7997
 	category = Utility
 	subcategory = 0
 	title = MEU-500 Pulse Drill
@@ -29,7 +29,7 @@ PART
 	tags = USI MKS drill MEU pulse resources surface harvester converter thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water
 
 	TechRequired = advScienceTech
-	entryCost = 50
+	entryCost = 23990
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 0,1,0,0,0

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02A.cfg
@@ -19,7 +19,7 @@ PART
 
 
 	// --- editor parameters ---
-	cost = 1300
+	cost = 8796
 	category = Utility
 	subcategory = 0
 	title = MEU-500-A Pulse Drill
@@ -29,7 +29,7 @@ PART
 	tags = USI MKS drill MEU pulse resources surface harvester converter thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water 
 
 	TechRequired = advScienceTech
-	entryCost = 50
+	entryCost = 26389
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 0,1,0,0,0

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03.cfg
@@ -19,7 +19,7 @@ PART
 
 
 	// --- editor parameters ---
-	cost = 6000
+	cost = 39994
 	category = Utility
 	subcategory = 0
 	title = Industrial Strip Miner
@@ -29,7 +29,7 @@ PART
 	tags = USI MKS drill industrial miner resources surface harvester converter thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water
 
 	TechRequired = advScienceTech
-	entryCost = 3000
+	entryCost = 119981
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 0,1,0,0,0

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03A.cfg
@@ -19,7 +19,7 @@ PART
 
 
 	// --- editor parameters ---
-	cost = 6000
+	cost = 43993
 	category = Utility
 	subcategory = 0
 	title = Automated Industrial Strip Miner
@@ -29,7 +29,7 @@ PART
 	tags = USI MKS drill industrial miner resources surface harvester converter thermal heat Uraninite Substrate Minerals ExoticMinerals RareMetals MaterialKits SpecializedParts Hydrates Gypsum Dirt Silicates Water 
 
 	TechRequired = advScienceTech
-	entryCost = 3000
+	entryCost = 131979
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 0,1,0,0,0


### PR DESCRIPTION
This fixes #1327: the MKS drills are much too cheap, cheaper than the corresponding stock drills
despite being more capable.  I've increased each drill's cost (including entryCost) to be the cost of its stock counterpart multiplied by the mass ratio between the two parts.  Specifically:

 * The MEU-100 weighs 11.2% more than the stock Drill-O-Matic Junior, and now it also costs 11.2% more.
 * The MEU-500 weighs 33.28% more than the stock Drill-O-Matic, and now it also costs 33.28% more.
 * The Industrial Strip Miner weighs 566.56% more than the stock Drill-O-Matic, and now it also costs 566.56% more.

The drills' automated variants cost an additional 10%, to reflect the additional built-in control systems needed to operate efficiently without an engineer present.

(If you'd rather base the drill costs on some other factor besides part mass ratios, let me know.  I just figured I'd take a stab at the issue with something that's better than the old costs.)