### PR TITLE
Fixes in Astronaut Complex UI

### DIFF
--- a/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
+++ b/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
@@ -59,16 +59,16 @@ namespace KolonyTools.AC
             _kolonists.Add(new Kolonist { Name = "Pilot", isBase = true, Effects = "Autopilot, VesselControl, RepBoost, Logistics, Explorer" });
             _kolonists.Add(new Kolonist { Name = "Scientist", isBase = true, Effects = "Science, Experiment, Botany, Agronomy, Medical, ScienceBoost" });
             _kolonists.Add(new Kolonist { Name = "Engineer", isBase = true, Effects = "Repair, Converter, Drill, Geology, FundsBoost" });
-            _kolonists.Add(new Kolonist { Name = "Kolonist", isBase = true, Effects = "RepBoost, FundsBoost, ScienceBoost" });
-            _kolonists.Add(new Kolonist { Name = "Miner", isBase = true, Effects = "Drill, FundsBoost" });
-            _kolonists.Add(new Kolonist { Name = "Technician", isBase = true, Effects = "Converter, FundsBoost" });
-            _kolonists.Add(new Kolonist { Name = "Mechanic", isBase = true, Effects = "Repair, FundsBoost" });
-            _kolonists.Add(new Kolonist { Name = "Biologist", isBase = true, Effects = "Biology, ScienceBoost" });
-            _kolonists.Add(new Kolonist { Name = "Geologist", isBase = true, Effects = "Geology, FundsBoost" });
-            _kolonists.Add(new Kolonist { Name = "Farmer", isBase = true, Effects = "Agronomy, ScienceBoost, RepBoost" });
-            _kolonists.Add(new Kolonist { Name = "Medic", isBase = true, Effects = "Medical, ScienceBoost, RepBoost" });
-            _kolonists.Add(new Kolonist { Name = "Quartermaster", isBase = true, Effects = "Logistics, RepBoost" });
-            _kolonists.Add(new Kolonist { Name = "Scout", isBase = true, Effects = "Explorer" });
+            _kolonists.Add(new Kolonist { Name = "Kolonist", isBase = false, Effects = "RepBoost, FundsBoost, ScienceBoost" });
+            _kolonists.Add(new Kolonist { Name = "Miner", isBase = false, Effects = "Drill, FundsBoost" });
+            _kolonists.Add(new Kolonist { Name = "Technician", isBase = false, Effects = "Converter, FundsBoost" });
+            _kolonists.Add(new Kolonist { Name = "Mechanic", isBase = false, Effects = "Repair, FundsBoost" });
+            _kolonists.Add(new Kolonist { Name = "Biologist", isBase = false, Effects = "Biology, ScienceBoost" });
+            _kolonists.Add(new Kolonist { Name = "Geologist", isBase = false, Effects = "Geology, FundsBoost" });
+            _kolonists.Add(new Kolonist { Name = "Farmer", isBase = false, Effects = "Agronomy, ScienceBoost, RepBoost" });
+            _kolonists.Add(new Kolonist { Name = "Medic", isBase = false, Effects = "Medical, ScienceBoost, RepBoost" });
+            _kolonists.Add(new Kolonist { Name = "Quartermaster", isBase = false, Effects = "Logistics, RepBoost" });
+            _kolonists.Add(new Kolonist { Name = "Scout", isBase = false, Effects = "Explorer" });
             KGendArray = new GUIContent[3] { KGRandom, KMale, KFemale };
         }
 

--- a/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
+++ b/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
@@ -74,15 +74,17 @@ namespace KolonyTools.AC
 
         public void Initialize(Rect guiRect)
         {
-            var uiScaleMultiplier = GameSettings.UI_SCALE;
+            //var uiScaleMultiplier = GameSettings.UI_SCALE;
 
             // the supplied rect will have the UI scalar already factored in
             //
             // to respect the player's UI scale wishes, work out what the unscaled rect
             // would be. Then we'll apply the scale again in OnGUI so all of our GUILayout elements
             // will respect the multiplier
-            var correctedRect = new Rect(guiRect.x, guiRect.y, guiRect.width / uiScaleMultiplier,
-                guiRect.height / uiScaleMultiplier);
+            //var correctedRect = new Rect(guiRect.x, guiRect.y, guiRect.width / uiScaleMultiplier,
+            //    guiRect.height / uiScaleMultiplier);
+
+            var correctedRect = new Rect(guiRect.x, guiRect.y, guiRect.width, guiRect.height);
 
             _areaRect = correctedRect;
 

--- a/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
+++ b/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
@@ -216,11 +216,6 @@ namespace KolonyTools.AC
             if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER)
             {
                 double kredits = Funding.Instance.Funds;
-                if (costMath() > kredits)
-                {
-                    bText = "Not Enough Funds!";
-                    hTest = false;
-                }
                 if (HighLogic.CurrentGame.CrewRoster.GetActiveCrewCount() >= GameVariables.Instance.GetActiveCrewLimit(ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.AstronautComplex)))
                 {
                     bText = "Roster is Full!";
@@ -228,7 +223,13 @@ namespace KolonyTools.AC
                 }
                 else
                 {
-                    hTest = true;
+                    if (costMath() > kredits)
+                    {
+                        bText = "Not Enough Funds!";
+                        hTest = false;
+                    }
+                    else
+                        hTest = true;
                 }
             }
             return bText;
@@ -390,15 +391,14 @@ namespace KolonyTools.AC
                 GUILayout.BeginHorizontal();
                 GUILayout.FlexibleSpace();
 
+                string statusText = hireStatus();
                 if (hTest)
                 {
-                    if (GUILayout.Button(hireStatus(), GUILayout.Width(200f)))
+                    if (GUILayout.Button(statusText, GUILayout.Width(200f)))
                         kHire();
                 }
-                if (!hTest)
-                {
-                    GUILayout.Button(hireStatus(), GUILayout.Width(200f));
-                }
+                else
+                    GUILayout.Button(statusText, GUILayout.Width(200f));
 
                 GUILayout.FlexibleSpace();
                 GUILayout.EndHorizontal();

--- a/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
+++ b/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
@@ -89,6 +89,13 @@ namespace KolonyTools.AC
             _areaRect = correctedRect;
 
             enabled = true;
+
+            // Reset of the basic Stupidity and Courage if the customization of Kerbonauts is disabled during game
+            if (!KolonyACOptions.CustomKerbonautsEnabled)
+            {
+                KStupidity = 50;
+                KCourage = 50;
+            }
         }
 
         private void kHire()

--- a/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
+++ b/Source/KolonyTools/KolonyTools/AC/CustomAstronautComplexUI.cs
@@ -44,7 +44,7 @@ namespace KolonyTools.AC
         {
             public StaticLoader()
             {
-                Debug.Log("InitStaticData");
+                //Debug.Log("InitStaticData");
                 for (int level = 1; level <= 5; level++)
                 {
                     var expValue = GetExperienceNeededFor(level);
@@ -97,7 +97,7 @@ namespace KolonyTools.AC
             {
                 double myFunds = Funding.Instance.Funds;
                 Funding.Instance.AddFunds(-costMath(), TransactionReasons.CrewRecruited);
-                Debug.Log("KSI :: Total Funds removed " + costMath());
+                //Debug.Log("KSI :: Total Funds removed " + costMath());
             }
 
             for (int i = 0; i < KBulki; i++)
@@ -145,12 +145,12 @@ namespace KolonyTools.AC
                 {
                     newKerb.experience = 9999;
                     newKerb.experienceLevel = 5;
-                    Debug.Log("KSI :: Level set to 5 - Non-Career Mode default.");
+                    //Debug.Log("KSI :: Level set to 5 - Non-Career Mode default.");
                 }
             }
 
             // Refreshes the AC so that new kerbal shows on the available roster.
-            Debug.Log("PSH :: Hiring Function Completed.");
+            //Debug.Log("PSH :: Hiring Function Completed.");
             GameEvents.onGUIAstronautComplexDespawn.Fire();
             GameEvents.onGUIAstronautComplexSpawn.Fire();
 
@@ -415,7 +415,7 @@ namespace KolonyTools.AC
             {
                 if (ac.ScrollListApplicants.Count > 0)
                 {
-                    Debug.Log("TRP: Clearing Applicant List");
+                    //Debug.Log("TRP: Clearing Applicant List");
                     ac.ScrollListApplicants.Clear(true);
                 }
             }

--- a/Source/KolonyTools/KolonyTools/KolonyOptions/KolonyACOptions.cs
+++ b/Source/KolonyTools/KolonyTools/KolonyOptions/KolonyACOptions.cs
@@ -98,7 +98,7 @@ namespace KolonyTools
             get
             {
                 KolonyACOptions options = HighLogic.CurrentGame.Parameters.CustomParams<KolonyACOptions>();
-                return options.AlternateCoreCost;
+                return options.AlternateKolonistCost;
             }
         }
 


### PR DESCRIPTION
Few fixes of the hire screen of the Astronaut Complex:

- Kerbals were hired with insufficient funds when in career mode
- Alternate hire cost was the same as the regular Kerbal cost (#1324)
- GUI rectangle is now scaled properly - only rectangle was fixed, individual elements are still unscaled as they were before (#1180)
- Reset of the basic Stupidity and Courage if the customization of Kerbonauts is disabled during game (#1325)
- Some debug messages were commented out to clean the KSP log
- AlternateKolonistCost option state was read incorectly from AlternateCoreCost