### PR TITLE
Add missing closing brace to stock FuelCell water-output patch

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/StockTweaks.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/StockTweaks.cfg
@@ -72,6 +72,7 @@
 			DumpExcess = true			
 		}
 	}
+}
 
 @PART[MiniDrill]
 {


### PR DESCRIPTION
This patch's closing brace was accidentally omitted in a merge conflict resolution awhile back, which broke the stock MiniDrill attachment node patch that follows it in the file.