### PR TITLE
Fix Ranger ISM's LiquidFuel/Oxidizer ratio

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_ISM.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Ranger_ISM.cfg
@@ -67,7 +67,7 @@ PART
 	{
 		name = FSfuelSwitch
 		resourceNames = Silicates,Silicon;Substrate,Polymers;ExoticMinerals,RareMetals,Chemicals,RefinedExotics;Hydrates,Water;Karbonite,Water;Ore,Water;Minerals,Chemicals;Gypsum,Fertilizer;Minerals,Fertilizer;MetallicOre,Metals;Ore,LiquidFuel,Oxidizer;Ore,LiquidFuel;Ore,MonoPropellant;RefinedExotics,Silicon,SpecializedParts;Metals,Polymers,Chemicals,MaterialKits;Substrate,Water,Organics,Fertilizer;Dirt,Water,Organics,Fertilizer;Organics,SpecializedParts,MaterialKits,ColonySupplies;SpecializedParts,MaterialKits,Machinery;Recyclables,Metals,Polymers,Chemicals;Mulch,Fertilizer,Supplies;Substrate,Water,Fertilizer,Supplies;Dirt,Water,Fertilizer,Supplies
-		resourceAmounts = 55,11;55,11;11.5,11.5,34.5,11.5;46,23;55,11;55,11;55,11;46,23;55,11;55,11;55,6.05,4.95;55,11;55,11;4.38,43.75,21.88;14,14,7,35;30.6,30.6,8.6,1;32,32,5.8,1;21,7,7,35;7,28,35;35,7,7,7;31.5,3.5,35;78,78,1,7.8;34.2,34.2,1,1.4
+		resourceAmounts = 55,11;55,11;11.5,11.5,34.5,11.5;46,23;55,11;55,11;55,11;46,23;55,11;55,11;55,4.95,6.05;55,11;55,11;4.38,43.75,21.88;14,14,7,35;30.6,30.6,8.6,1;32,32,5.8,1;21,7,7,35;7,28,35;35,7,7,7;31.5,3.5,35;78,78,1,7.8;34.2,34.2,1,1.4
 		initialResourceAmounts = 0,0;0,0;0,0,0,0;0,0;0,0;0,0;0,0;0,0;0,0;0,0;0,0,0;0,0;0,0;0,0,0;0,0,0,0;0,0,0,0;0,0,0,0;0,0,0,0;0,0,0;0,0,0,0;0,0,0;0,0,0,0;0,0,0,0
 		tankCost = 3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500;3500
 		hasGUI = false


### PR DESCRIPTION
LFO engines consume LiquidFuel and Oxidizer in a 9:11 ratio, and fuel tanks' capacities typically follow that same ratio.  This one had them the other way around (11:9), which presumably was a mistake.