### PR TITLE
Add silicon to MPU's

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor125.cfg
@@ -428,6 +428,74 @@ PART
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
+		ConverterName = Silicon
+		StartActionName = Start Silicon
+		StopActionName = Stop Silicon
+		Efficiency = 1	
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Silicates
+			Ratio =  0.0013
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.56
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Silcon
+			Ratio = 0.00026
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE:NEEDS[ART]
+		{
+			ResourceName = Rock
+			Ratio =  0.00026
+			DumpExcess = true
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00000045
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00000045
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 90
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
 		ConverterName = Fertilizer(G)
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor125.cfg
@@ -428,74 +428,6 @@ PART
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
-		ConverterName = Silicon
-		StartActionName = Start Silicon
-		StopActionName = Stop Silicon
-		Efficiency = 1	
-		AutoShutdown = true
-		GeneratesHeat = true
-		UseSpecialistBonus = false
-		TemperatureModifier
-		{
-			key = 0 10000
-			key = 500 5000
-			key = 1000 2500
-			key = 1250 2500
-			key = 1500 500
-			key = 2000 0
-		}		
-		ThermalEfficiency 
-		{
-			key = 0 0
-			key = 500 0.25
-			key = 1000 1.0
-			key = 1250 0.5
-			key = 1500 0.1
-			key = 2000 0
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Silicates
-			Ratio =  0.0013
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 1.56
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Silcon
-			Ratio = 0.00026
-			DumpExcess = False
-		}
-		OUTPUT_RESOURCE:NEEDS[ART]
-		{
-			ResourceName = Rock
-			Ratio =  0.00026
-			DumpExcess = true
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 0.00000045
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Recyclables
-			Ratio = 0.00000045
-			DumpExcess = true
-		}
-		REQUIRED_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 90
-		}
-	}
-
-	MODULE
-	{
-		name = ModuleResourceConverter_USI
 		ConverterName = Fertilizer(G)
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)
@@ -683,7 +615,75 @@ PART
 			Ratio = 0.00000045
 			DumpExcess = true
 		}
-	}				
+	}
+	
+		MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = Silicon
+		StartActionName = Start Silicon
+		StopActionName = Stop Silicon
+		Efficiency = 1	
+		AutoShutdown = true
+		GeneratesHeat = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 10000
+			key = 500 5000
+			key = 1000 2500
+			key = 1250 2500
+			key = 1500 500
+			key = 2000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.25
+			key = 1000 1.0
+			key = 1250 0.5
+			key = 1500 0.1
+			key = 2000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Silicates
+			Ratio =  0.0013
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1.56
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Silcon
+			Ratio = 0.00026
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE:NEEDS[ART]
+		{
+			ResourceName = Rock
+			Ratio =  0.00026
+			DumpExcess = true
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00000045
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00000045
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 90
+		}
+	}
 	
 	MODULE
 	{

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
@@ -427,74 +427,6 @@ PART
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
-		ConverterName = Silicon
-		StartActionName = Start Silicon
-		StopActionName = Stop Silicon
-		Efficiency = 1	
-		GeneratesHeat = true
-		AutoShutdown = true
-		UseSpecialistBonus = false
-		TemperatureModifier
-		{
-			key = 0 50000
-			key = 500 20000
-			key = 1000 5000
-			key = 1500 2500
-			key = 2000 500
-			key = 3000 0
-		}		
-		ThermalEfficiency 
-		{
-			key = 0 0
-			key = 500 0.15
-			key = 1000 1.0
-			key = 1500 0.25
-			key = 2000 0.1
-			key = 3000 0
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Silicates
-			Ratio =  0.0047
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 5.64
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Silicon
-			Ratio = 0.00094
-			DumpExcess = False
-		}
-		OUTPUT_RESOURCE:NEEDS[ART]
-		{
-			ResourceName = Rock
-			Ratio =  0.00094
-			DumpExcess = true
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 0.00000325
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Recyclables
-			Ratio = 0.00000325
-			DumpExcess = true
-		}
-		REQUIRED_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 650
-		}
-	}		
-
-	MODULE
-	{
-		name = ModuleResourceConverter_USI
 		ConverterName = Fertilizer(G)
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)
@@ -682,6 +614,74 @@ PART
 		}
 	}				
 	
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = Silicon
+		StartActionName = Start Silicon
+		StopActionName = Stop Silicon
+		Efficiency = 1	
+		GeneratesHeat = true
+		AutoShutdown = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.15
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Silicates
+			Ratio =  0.0047
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 5.64
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Silicon
+			Ratio = 0.00094
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE:NEEDS[ART]
+		{
+			ResourceName = Rock
+			Ratio =  0.00094
+			DumpExcess = true
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00000325
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00000325
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 650
+		}
+	}		
+
 	MODULE
 	{
 		name = USI_ModuleFieldRepair

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor250.cfg
@@ -427,6 +427,74 @@ PART
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
+		ConverterName = Silicon
+		StartActionName = Start Silicon
+		StopActionName = Stop Silicon
+		Efficiency = 1	
+		GeneratesHeat = true
+		AutoShutdown = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 500 20000
+			key = 1000 5000
+			key = 1500 2500
+			key = 2000 500
+			key = 3000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.15
+			key = 1000 1.0
+			key = 1500 0.25
+			key = 2000 0.1
+			key = 3000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Silicates
+			Ratio =  0.0047
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 5.64
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Silicon
+			Ratio = 0.00094
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE:NEEDS[ART]
+		{
+			ResourceName = Rock
+			Ratio =  0.00094
+			DumpExcess = true
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00000325
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00000325
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 650
+		}
+	}		
+
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
 		ConverterName = Fertilizer(G)
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
@@ -439,76 +439,6 @@ PART
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
-		ConverterName = Silicon
-		StartActionName = Start Silicon
-		StopActionName = Stop Silicon
-		Efficiency = 1
-		GeneratesHeat = true
-		AutoShutdown = true
-		UseSpecialistBonus = false
-		TemperatureModifier
-		{
-			key = 0 100000
-			key = 500 50000
-			key = 1000 10000
-			key = 1500 10000
-			key = 2000 2500
-			key = 3000 500
-			key = 4000 0
-		}		
-		ThermalEfficiency 
-		{
-			key = 0 0
-			key = 500 0.1
-			key = 1000 0.25
-			key = 1500 1.0
-			key = 2000 0.5
-			key = 3000 0.1
-			key = 4000 0
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Silicates
-			Ratio =  0.01
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 12
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Silicon
-			Ratio = 0.002
-			DumpExcess = False
-		}
-		OUTPUT_RESOURCE:NEEDS[ART]
-		{
-			ResourceName = Rock
-			Ratio =  0.002
-			DumpExcess = true
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 0.00001
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Recyclables
-			Ratio = 0.00001
-			DumpExcess = true
-		}
-		REQUIRED_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 2000
-		}
-	}		
-
-	MODULE
-	{
-		name = ModuleResourceConverter_USI
 		ConverterName = Fertilizer(G)
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)
@@ -703,6 +633,76 @@ PART
 		}
 	}				
 	
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = Silicon
+		StartActionName = Start Silicon
+		StopActionName = Stop Silicon
+		Efficiency = 1
+		GeneratesHeat = true
+		AutoShutdown = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Silicates
+			Ratio =  0.01
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 12
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Silicon
+			Ratio = 0.002
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE:NEEDS[ART]
+		{
+			ResourceName = Rock
+			Ratio =  0.002
+			DumpExcess = true
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00001
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00001
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 2000
+		}
+	}		
+
 	MODULE
 	{
 		name = USI_ModuleFieldRepair

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Processor375.cfg
@@ -439,6 +439,76 @@ PART
 	MODULE
 	{
 		name = ModuleResourceConverter_USI
+		ConverterName = Silicon
+		StartActionName = Start Silicon
+		StopActionName = Stop Silicon
+		Efficiency = 1
+		GeneratesHeat = true
+		AutoShutdown = true
+		UseSpecialistBonus = false
+		TemperatureModifier
+		{
+			key = 0 100000
+			key = 500 50000
+			key = 1000 10000
+			key = 1500 10000
+			key = 2000 2500
+			key = 3000 500
+			key = 4000 0
+		}		
+		ThermalEfficiency 
+		{
+			key = 0 0
+			key = 500 0.1
+			key = 1000 0.25
+			key = 1500 1.0
+			key = 2000 0.5
+			key = 3000 0.1
+			key = 4000 0
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Silicates
+			Ratio =  0.01
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 12
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Silicon
+			Ratio = 0.002
+			DumpExcess = False
+		}
+		OUTPUT_RESOURCE:NEEDS[ART]
+		{
+			ResourceName = Rock
+			Ratio =  0.002
+			DumpExcess = true
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.00001
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.00001
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 2000
+		}
+	}		
+
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
 		ConverterName = Fertilizer(G)
 		StartActionName = Start Fertilizer(G)
 		StopActionName = Stop Fertilizer(G)


### PR DESCRIPTION
This adds Silicon to the Material Processing Unit.  I want to do this as there is no difference between Silicon and Metals, Polymers, or Chemicals.  This allows the MPU's to perform 1st to 2nd level processing of Silicon which is the parts primary role.