### PR TITLE
Restore Transport Credits buttons

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Duna_LogCenter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Duna_LogCenter.cfg
@@ -152,4 +152,48 @@ PART
 	{
 		name = ModuleOrbitalLogistics
 	}
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = Transport Credits
+		StartActionName = Start T-Credits
+		StopActionName = Stop T-Credits
+
+		UseSpecialistBonus = false
+		Efficiency = 1
+
+		INPUT_RESOURCE
+		{
+			ResourceName = MaterialKits
+			Ratio = 0.2
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = LiquidFuel
+			Ratio = 0.45
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Oxidizer
+			Ratio = 0.55
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = TransportCredits
+			Ratio = 1
+			DumpExcess = true
+		}
+	}
+	RESOURCE
+	{
+		name = TransportCredits
+		amount = 0
+		maxAmount = 100000
+		isTweakable = false
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_PioneerLC.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_PioneerLC.cfg
@@ -192,4 +192,48 @@ PART
 	{
 		name = ModuleOrbitalLogistics
 	}
+	MODULE
+	{
+		name = ModuleResourceConverter_USI
+		ConverterName = Transport Credits
+		StartActionName = Start T-Credits
+		StopActionName = Stop T-Credits
+
+		UseSpecialistBonus = false
+		Efficiency = 1
+
+		INPUT_RESOURCE
+		{
+			ResourceName = MaterialKits
+			Ratio = 0.2
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = LiquidFuel
+			Ratio = 0.45
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Oxidizer
+			Ratio = 0.55
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = TransportCredits
+			Ratio = 1
+			DumpExcess = true
+		}
+	}
+	RESOURCE
+	{
+		name = TransportCredits
+		amount = 0
+		maxAmount = 100000
+		isTweakable = false
+	}
 }


### PR DESCRIPTION
The last update remove the ability to create Transport Credits.
Here is the rollback.