### PR TITLE
Fix industrial drills

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02.cfg
@@ -10,7 +10,6 @@ PART
 	MODEL
 	{
 	   model = Squad/Parts/Resources/RadialDrill/TriBitDrill
-	   texture = TriBitDrill, UmbraSpaceIndustries/MKS/Assets/TriBitDrill_RD
 	   scale = 1,1,1
 	}
 
@@ -382,5 +381,23 @@ PART
 	MODULE
 	{
 		name = MKSModule
+	}
+
+	MODULE
+	{
+		name = ModulePartVariants
+		baseVariant = Invariant
+		VARIANT
+		{
+			name = Invariant
+			displayName = Invariant
+			primaryColor = #000000
+			secondaryColor = #000000
+			TEXTURE
+			{
+				materialName = Drill_Fixed
+				mainTextureURL = UmbraSpaceIndustries/MKS/Assets/TriBitDrill_RD
+			}
+		}
 	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_02A.cfg
@@ -10,7 +10,6 @@ PART
 	MODEL
 	{
 	   model = Squad/Parts/Resources/RadialDrill/TriBitDrill
-	   texture = TriBitDrill, UmbraSpaceIndustries/MKS/Assets/TriBitDrill_GN
 	   scale = 1,1,1
 	}
 	
@@ -374,4 +373,22 @@ PART
 	{
 		name = MKSModule
 	}	
+
+	MODULE
+	{
+		name = ModulePartVariants
+		baseVariant = Invariant
+		VARIANT
+		{
+			name = Invariant
+			displayName = Invariant
+			primaryColor = #000000
+			secondaryColor = #000000
+			TEXTURE
+			{
+				materialName = Drill_Fixed
+				mainTextureURL = UmbraSpaceIndustries/MKS/Assets/TriBitDrill_GN
+			}
+		}
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03.cfg
@@ -10,7 +10,6 @@ PART
 	MODEL
 	{
 	   model = Squad/Parts/Resources/RadialDrill/TriBitDrill
-	   texture = TriBitDrill, UmbraSpaceIndustries/MKS/Assets/TriBitDrill_WT
 	   scale = 2,2,2
 	}
 
@@ -481,5 +480,23 @@ PART
 	MODULE
 	{
 		name = MKSModule
+	}
+
+	MODULE
+	{
+		name = ModulePartVariants
+		baseVariant = Invariant
+		VARIANT
+		{
+			name = Invariant
+			displayName = Invariant
+			primaryColor = #000000
+			secondaryColor = #000000
+			TEXTURE
+			{
+				materialName = Drill_Fixed
+				mainTextureURL = UmbraSpaceIndustries/MKS/Assets/TriBitDrill_WT
+			}
+		}
 	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03A.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_Drill_03A.cfg
@@ -10,7 +10,6 @@ PART
 	MODEL
 	{
 	   model = Squad/Parts/Resources/RadialDrill/TriBitDrill
-	   texture = TriBitDrill, UmbraSpaceIndustries/MKS/Assets/TriBitDrill_YL
 	   scale = 2,2,2
 	}
 	
@@ -464,5 +463,23 @@ PART
 	MODULE
 	{
 		name = MKSModule
+	}
+
+	MODULE
+	{
+		name = ModulePartVariants
+		baseVariant = Invariant
+		VARIANT
+		{
+			name = Invariant
+			displayName = Invariant
+			primaryColor = #000000
+			secondaryColor = #000000
+			TEXTURE
+			{
+				materialName = Drill_Fixed
+				mainTextureURL = UmbraSpaceIndustries/MKS/Assets/TriBitDrill_YL
+			}
+		}
 	}
 }


### PR DESCRIPTION
Use the new ModulePartVariant to fix drill part loading.
The drawback is that even with one variant, the multi-skin icon is shown in VAB/SPH UI.

From my POV, it should be considered as a temporary workaround (even if apparently fully working), waiting for the stock texture replacement to correctly work.
