### PR TITLE
375 Reactor DepletedFuel

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ReactorPack/Parts/Nuke_375.cfg
@@ -63,7 +63,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = DepletedFuel
-			Ratio = 0.000018
+			Ratio = 0.000012
 			DumpExcess = true		
 		}
 		OUTPUT_RESOURCE


### PR DESCRIPTION
The 375 reactor was putting out the same amount of depleted uranium as it's enriched uranium intake.