### PR TITLE
Fix Karibou tank costs & increase tanks' LH2 capacity 1.5x to match CryoTanks change

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Adapter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Adapter.cfg
@@ -59,7 +59,7 @@ PART
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant;MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt;Silicates;Silicon;RefinedExotics;ColonySupplies;Organics
 		resourceAmounts = 225,275;2500;2500;2500;2500;500;500;2500;2500;2500;2500;2500;1250,1250;2500;2500;2500;2500;500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500
 		initialResourceAmounts = 225,275;0;0;0;0;500;500;0;0;0;0;0;0,0;0;0;0;0;2500;0;0;0;0;0;0;0;0;0;0;0;0;0
-		tankCost = 1000;1000;40000;1000;1000;1000;1500;7000;5000;4000;5000;4000;327000;5000;38000;22000;39000;600;50000;25000;100000;14000;1250;25;750;25;50;625000;37500;1500
+		tankCost = 229.5;2.5125;40000;0;91.875;400;600;4400;1750;750;2000;800;375000;5000;35600;20000;6250;10;39500;17500;80000;5000;1250;25;750;25;50;625000;37500;1250
 		basePartMass = 0.5
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Adapter.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Adapter.cfg
@@ -57,9 +57,9 @@ PART
 	{
 		name = FSfuelSwitch
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant;MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt;Silicates;Silicon;RefinedExotics;ColonySupplies;Organics
-		resourceAmounts = 225,275;2500;2500;2500;2500;500;500;2500;2500;2500;2500;2500;1250,1250;2500;2500;2500;2500;500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500
+		resourceAmounts = 225,275;2500;2500;2500;3750;500;500;2500;2500;2500;2500;2500;1250,1250;2500;2500;2500;2500;500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500
 		initialResourceAmounts = 225,275;0;0;0;0;500;500;0;0;0;0;0;0,0;0;0;0;0;2500;0;0;0;0;0;0;0;0;0;0;0;0;0
-		tankCost = 229.5;2.5125;40000;0;91.875;400;600;4400;1750;750;2000;800;375000;5000;35600;20000;6250;10;39500;17500;80000;5000;1250;25;750;25;50;625000;37500;1250
+		tankCost = 229.5;2.5125;40000;0;137.8125;400;600;4400;1750;750;2000;800;375000;5000;35600;20000;6250;10;39500;17500;80000;5000;1250;25;750;25;50;625000;37500;1250
 		basePartMass = 0.5
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Crate.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Crate.cfg
@@ -52,7 +52,7 @@ PART
 		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt;Silicates;Silicon;RefinedExotics;ColonySupplies;Organics
 		resourceAmounts = 2500;2500;2500;2500;2500;1250,1250;2500;2500;2500;2500;500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500;2500
 		initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
-		tankCost = 4400;1750;750;2000;800;375000;5000;35600;20000;6250;10;39500;17500;80000;5000;1250;25;750;25;50;625000;37500;1500
+		tankCost = 4400;1750;750;2000;800;375000;5000;35600;20000;6250;10;39500;17500;80000;5000;1250;25;750;25;50;625000;37500;1250
 		basePartMass = 0.4
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Tank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Tank.cfg
@@ -53,7 +53,7 @@ PART
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
 		resourceAmounts = 225,275;2500;2500;2500;2500;500;500
 		initialResourceAmounts = 0,0;0;0;0;0;0;0
-		tankCost = 229.5;2;40000;0;91.875;400;600
+		tankCost = 229.5;2.5125;40000;0;91.875;400;600
 		basePartMass = 0.4
 		tankMass = 0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Tank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Tank.cfg
@@ -51,9 +51,9 @@ PART
 	{
 		name = FSfuelSwitch
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
-		resourceAmounts = 225,275;2500;2500;2500;2500;500;500
+		resourceAmounts = 225,275;2500;2500;2500;3750;500;500
 		initialResourceAmounts = 0,0;0;0;0;0;0;0
-		tankCost = 229.5;2.5125;40000;0;91.875;400;600
+		tankCost = 229.5;2.5125;40000;0;137.8125;400;600
 		basePartMass = 0.4
 		tankMass = 0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay.cfg
@@ -61,9 +61,9 @@ PART
 	{
 		name = FSfuelSwitch
 		resourceNames =   LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant;MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt;Silicates;Silicon;RefinedExotics;ColonySupplies;Organics
-		resourceAmounts =        900,    1100;10000;    10000;10000;      10000;      2000;          2000;      10000;    10000;    10000;   10000;    10000;          5000,      5000;       10000; 10000;   10000;  10000;2000;    10000;      10000;           10000;     10000;   10000;10000;10000;    10000;  10000;         10000;         10000;10000
+		resourceAmounts =        900,    1100;10000;    10000;10000;      15000;      2000;          2000;      10000;    10000;    10000;   10000;    10000;          5000,      5000;       10000; 10000;   10000;  10000;2000;    10000;      10000;           10000;     10000;   10000;10000;10000;    10000;  10000;         10000;         10000;10000
 		initialResourceAmounts = 900,    1100;    0;        0;    0;          0;      2000;          2000;          0;        0;        0;       0;        0;             0,         0;           0;     0;       0;  10000;   0;        0;          0;               0;         0;       0;    0;    0;        0;      0;             0;             0;    0	
-		tankCost =     918;10.05;160000;0;367.5;1600;2400;17600;7000;3000;8000;3200;1500000;20000;142400;80000;25000;40;158000;70000;320000;20000;5000;100;3000;100;200;2500000;150000;5000
+		tankCost =     918;10.05;160000;0;551.25;1600;2400;17600;7000;3000;8000;3200;1500000;20000;142400;80000;25000;40;158000;70000;320000;20000;5000;100;3000;100;200;2500000;150000;5000
 		basePartMass = 2
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay.cfg
@@ -63,7 +63,7 @@ PART
 		resourceNames =   LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant;MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt;Silicates;Silicon;RefinedExotics;ColonySupplies;Organics
 		resourceAmounts =        900,    1100;10000;    10000;10000;      10000;      2000;          2000;      10000;    10000;    10000;   10000;    10000;          5000,      5000;       10000; 10000;   10000;  10000;2000;    10000;      10000;           10000;     10000;   10000;10000;10000;    10000;  10000;         10000;         10000;10000
 		initialResourceAmounts = 900,    1100;    0;        0;    0;          0;      2000;          2000;          0;        0;        0;       0;        0;             0,         0;           0;     0;       0;  10000;   0;        0;          0;               0;         0;       0;    0;    0;        0;      0;             0;             0;    0	
-		tankCost =     918;8;160000;0;367.5;1600;2400;17600;7000;3000;8000;3200;1500000;20000;142400;80000;25000;40;158000;70000;320000;20000;5000;100;3000;100;200;2500000;150000;5000
+		tankCost =     918;10.05;160000;0;367.5;1600;2400;17600;7000;3000;8000;3200;1500000;20000;142400;80000;25000;40;158000;70000;320000;20000;5000;100;3000;100;200;2500000;150000;5000
 		basePartMass = 2
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay_Short.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay_Short.cfg
@@ -61,9 +61,9 @@ PART
 	{
 		name = FSfuelSwitch
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant;MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt;Silicates;Silicon;RefinedExotics;ColonySupplies;Organics
-		resourceAmounts = 450,550;5000;5000;5000;5000;1000;1000;5000;5000;5000;5000;5000;2500,2500;5000;5000;5000;5000;1000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000
+		resourceAmounts = 450,550;5000;5000;5000;7500;1000;1000;5000;5000;5000;5000;5000;2500,2500;5000;5000;5000;5000;1000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000
 		initialResourceAmounts = 450,550;0;0;0;0;1000;1000;0;0;0;0;0;0,0;0;0;0;5000;0;0;0;0;0;0;0;0;0;0;0;0;0
-		tankCost = 459;5.025;80000;0;183.75;800;1200;8800;3500;1500;4000;1600;750000;10000;71200;40000;12500;20;79000;35000;160000;10000;2500;50;1500;50;100;1250000;75000;2500
+		tankCost = 459;5.025;80000;0;275.625;800;1200;8800;3500;1500;4000;1600;750000;10000;71200;40000;12500;20;79000;35000;160000;10000;2500;50;1500;50;100;1250000;75000;2500
 		basePartMass = 1
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay_Short.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay_Short.cfg
@@ -63,7 +63,7 @@ PART
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant;MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt;Silicates;Silicon;RefinedExotics;ColonySupplies;Organics
 		resourceAmounts = 450,550;5000;5000;5000;5000;1000;1000;5000;5000;5000;5000;5000;2500,2500;5000;5000;5000;5000;1000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000;5000
 		initialResourceAmounts = 450,550;0;0;0;0;1000;1000;0;0;0;0;0;0,0;0;0;0;5000;0;0;0;0;0;0;0;0;0;0;0;0;0
-		tankCost = 459;4;80000;0;183.75;4000;1200;8800;3500;1500;4000;1600;750000;10000;71200;40000;12500;20;79000;35000;160000;10000;2500;50;1500;50;100;1250000;75000;2500
+		tankCost = 459;5.025;80000;0;183.75;800;1200;8800;3500;1500;4000;1600;750000;10000;71200;40000;12500;20;79000;35000;160000;10000;2500;50;1500;50;100;1250000;75000;2500
 		basePartMass = 1
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false


### PR DESCRIPTION
Same as UmbraSpaceIndustries/USI_Core#108, but for the Karibou parts.  Pinging @ChrisAdderley on this one too.

I also updated all the switchers' `tankCost` values based on the resources' current CRP `unitCost` values.  Many of the tank costs had been incorrect (including LH2, which is why I noticed).