### PR TITLE
Microwave Power Tranceiver without crew

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_PowerAntenna.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_PowerAntenna.cfg
@@ -30,7 +30,7 @@ category = Electrical
 subcategory = 0
 title = Microwave Power Tranceiver
 manufacturer = Umbra Space Industries
-description = Allows for the transfer of power via microwave transmission
+description = Allows for the transfer of power via microwave transmission. This advanced technology is reliable enough to transmit power even in remote bases without constant monitoring by technicians.
 
 tags = USI MKS power transfer tranceiver microwave transmission logistics consume distribut Distribute PDU 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_PowerAntenna.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/MKS_PowerAntenna.cfg
@@ -53,6 +53,7 @@ bulkheadProfiles = srf
 	{
 		name = ModulePowerDistributor
 		PowerDistributionRange = 2000
+		RequiredSkill =
 	}	
 	MODULE
 	{


### PR DESCRIPTION
For UmbraSpaceIndustries/MKS#1255: Allow the Microwave Power Tranceiver to operate in unmanned bases, giving it a unique advantage over the much cheaper but otherwise equally useful couplers. Requires https://github.com/UmbraSpaceIndustries/UmbraSpaceIndustries/pull/130