### PR TITLE
Bug fix: OrbLog failed transfers

### DIFF
--- a/Source/KolonyTools/KolonyTools/OrbitalLogistics/ModuleOrbitalLogistics.cs
+++ b/Source/KolonyTools/KolonyTools/OrbitalLogistics/ModuleOrbitalLogistics.cs
@@ -105,15 +105,6 @@ namespace KolonyTools
             }
         }
 
-        public override void OnLoad(ConfigNode node)
-        {
-            base.OnLoad(node);
-
-            string moduleId = string.Empty;
-            if (!node.TryGetValue("ModuleId", ref moduleId) || string.IsNullOrEmpty(moduleId))
-                ModuleId = Guid.NewGuid().ToString();
-        }
-
         /// <summary>
         /// Make a list of all valid tranfer vessels on this celestial body.
         /// </summary>
@@ -165,7 +156,13 @@ namespace KolonyTools
         {
             if (vessel.loaded)
             {
-                return vessel.FindPartModuleImplementing<ModuleOrbitalLogistics>().ModuleId;
+                var module = vessel.FindPartModuleImplementing<ModuleOrbitalLogistics>();
+                if (string.IsNullOrEmpty(module.ModuleId))
+                {
+                    module.ModuleId = Guid.NewGuid().ToString();
+                }
+
+                return module.ModuleId;
             }
             else
             {
@@ -175,7 +172,14 @@ namespace KolonyTools
                     {
                         if (module.moduleName == "ModuleOrbitalLogistics")
                         {
-                            return module.moduleValues.GetValue("ModuleId") ?? "unassigned";
+                            var moduleId = module.moduleValues.GetValue("ModuleId") ?? string.Empty;
+                            if (string.IsNullOrEmpty(moduleId))
+                            {
+                                moduleId = Guid.NewGuid().ToString();
+                                module.moduleValues.SetValue("ModuleId", moduleId, true);
+                            }
+
+                            return moduleId;
                         }
                     }
                 }

--- a/Source/KolonyTools/KolonyTools/OrbitalLogistics/OrbitalLogisticsTransferRequest.cs
+++ b/Source/KolonyTools/KolonyTools/OrbitalLogistics/OrbitalLogisticsTransferRequest.cs
@@ -78,6 +78,9 @@ namespace KolonyTools
         public DeliveryStatus Status = DeliveryStatus.PreLaunch;
 
         [Persistent]
+        public string StatusMessage;
+
+        [Persistent]
         public double Duration = 0;
 
         [Persistent]
@@ -286,6 +289,7 @@ namespace KolonyTools
             if (Origin == null || Destination == null)
             {
                 Status = DeliveryStatus.Failed;
+                StatusMessage = "The origin or destination vessel no longer exists.";
                 yield break;
             }
 
@@ -293,6 +297,7 @@ namespace KolonyTools
             if (Origin.mainBody != Destination.mainBody)
             {
                 Status = DeliveryStatus.Failed;
+                StatusMessage = "The origin and destination vessels are no longer in the same sphere of influence.";
                 yield break;
             }
 
@@ -301,6 +306,7 @@ namespace KolonyTools
                 || Destination.protoVessel.situation != (Destination.protoVessel.situation & ALLOWED_SITUATIONS))
             {
                 Status = DeliveryStatus.Failed;
+                StatusMessage = "The origin or destination vessel is no longer in an allowed situation for logistics transfers.";
                 yield break;
             }
 
@@ -309,6 +315,7 @@ namespace KolonyTools
             if (Destination != whoHasTheDestinationOrbLogModule)
             {
                 Status = DeliveryStatus.Failed;
+                StatusMessage = "The target logistics module could not be found on the destination vessel.";
                 yield break;
             }
 
@@ -339,7 +346,15 @@ namespace KolonyTools
             if (Status == DeliveryStatus.Returning)
                 Status = DeliveryStatus.Cancelled;
             else
-                Status = deliveredAll ? DeliveryStatus.Delivered : DeliveryStatus.Partial;
+            {
+                if (deliveredAll)
+                    Status = DeliveryStatus.Delivered;
+                else
+                {
+                    Status = DeliveryStatus.Partial;
+                    StatusMessage = "The destination vessel did not have enough available storage for the delivery.";
+                }
+            }
         }
 
         /// <summary>

--- a/Source/KolonyTools/KolonyTools/OrbitalLogistics/UI/OrbitalLogisticsGui_ReviewTransfer.cs
+++ b/Source/KolonyTools/KolonyTools/OrbitalLogistics/UI/OrbitalLogisticsGui_ReviewTransfer.cs
@@ -79,6 +79,14 @@ namespace KolonyTools
                 );
             GUILayout.EndHorizontal();
 
+            if (Transfer.Status == DeliveryStatus.Failed || Transfer.Status == DeliveryStatus.Partial)
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Reason:", UIHelper.whiteLabelStyle, GUILayout.Width(100));
+                GUILayout.Label(Transfer.StatusMessage, UIHelper.redRightAlignLabelStyle, GUILayout.MinWidth(100), GUILayout.MaxWidth(300));
+                GUILayout.EndHorizontal();
+            }
+
             GUILayout.Label("Resource Quantities", UIHelper.labelStyle, GUILayout.Width(200));
             _quantityScrollPosition = GUILayout.BeginScrollView(
                 _quantityScrollPosition,


### PR DESCRIPTION
Changed the way that ModuleOrbitalLogistics receives its ModuleId to prevent vessels based on the same .craft file having the same ModuleId; added a failure reason message to the UI