### PR TITLE
Update Tundra Kolonization Module Crew Capacity

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kolonist375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Parts/Tundra_Kolonist375.cfg
@@ -44,7 +44,7 @@ PART
 	breakingTorque= 2000
 	maxTemp = 1200 // = 2900
 	bulkheadProfiles = size3
-	CrewCapacity = 6
+	CrewCapacity = 12
 
 	INTERNAL
 	{


### PR DESCRIPTION
This PR fill fix #1464 by increasing the crew capacity to 12 Kerbals