### PR TITLE
Add WOLF connector part

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Localization/en-us.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Localization/en-us.cfg
@@ -134,6 +134,7 @@ Localization
         #autoLOC_USI_WOLF_RTG_PART_TITLE = WOLF PB-NUK Radioisotope Thermoelectric Generator
         #autoLOC_USI_WOLF_SCIENCEMODULE_PART_TITLE = WOLF Science Module
         #autoLOC_USI_WOLF_TRANSPORTER_PART_TITLE = WOLF Transport Computer
+        #autoLOC_USI_WOLF_CONNECTOR_PART_TITLE = WOLF Depot Connector
         #autoLOC_USI_WOLF_TRANSPORTMODULE_PART_TITLE = WOLF Transport Module
         #autoLOC_USI_WOLF_WASTEPROCESSOR_PART_TITLE = WOLF Waste Recycler Module
 
@@ -156,6 +157,7 @@ Localization
         #autoLOC_USI_WOLF_RTG_PART_DESCRIPTION = Through exploitation of the natural decay of Blutonium-238, this elegantly simple power generator can provide maintenance-free power for decades. Not to be used for providing heating during emergency rover excursions.
         #autoLOC_USI_WOLF_SCIENCEMODULE_PART_DESCRIPTION = The Science Module is required to support most LifeSupport-related modules.
         #autoLOC_USI_WOLF_TRANSPORTER_PART_DESCRIPTION = Use this to setup WOLF transportation routes between planets and biomes.
+        #autoLOC_USI_WOLF_CONNECTOR_PART_DESCRIPTION = Use this to connect vessels without other WOLF parts to a depot. Can be used to connect Crew-Only vessels to a depot.
         #autoLOC_USI_WOLF_TRANSPORTMODULE_PART_DESCRIPTION = The Transport Module produces Transport Credits that can be used to fund resource transfers between depots.
         #autoLOC_USI_WOLF_WASTEPROCESSOR_PART_DESCRIPTION = Turns waste materials into biomass.
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Connector.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Connector.cfg
@@ -1,0 +1,43 @@
+PART:NEEDS[USI_WOLF]
+{
+	name = WOLF_Connector
+	module = Part
+	author = SuMa
+
+	MODEL
+	{
+		model = UmbraSpaceIndustries/WOLF/Parts/FlightRecorder/FlightRecorder
+	}
+	scale = 1
+	rescaleFactor = 1
+
+	node_attach = 0.0, 0.0, 0.02, 0.0, 0.0, -1, 0
+
+	TechRequired = advScienceTech
+	entryCost = 2400
+	cost = 800
+	category = none
+	subcategory = 0
+	title = #autoLOC_USI_WOLF_CONNECTOR_PART_TITLE
+	manufacturer = #autoLOC_USI_WOLF_KOLONIZATION_DIVISION
+	description = #autoLOC_USI_WOLF_CONNECTOR_PART_DESCRIPTION
+
+	attachRules = 0,1,0,0,0
+
+	// --- standard part parameters ---
+	mass = 0.005
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 2
+	crashTolerance = 7
+	maxTemp = 2000 // = 3000
+	bulkheadProfiles = srf
+	tags = USI WOLF scanner transport route cck-usi-wolf
+
+	MODULE
+	{
+		name = WOLF_ConverterModule
+		PartInfo = #autoLOC_USI_WOLF_AGRICULTURE_PARTMODULE_INFO
+	}
+}


### PR DESCRIPTION
Add a new part that can be used to connect vessels without other WOLF-Modules to WOLF-Depot. Usefull to add only Crew without any converters to a depot.
Currently no additional model is made. Reuses FightComputer model