### PR TITLE
Fix converter ratio for LiquidFuel receip

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/HopperFuel375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/HopperFuel375.cfg
@@ -107,7 +107,7 @@ PART
 		OUTPUT_RESOURCE
 		{
 			ResourceName = LiquidFuel
-			Ratio = 0.0185185
+			Ratio = 0.0462963
 			DumpExcess = false
 		}
 	}


### PR DESCRIPTION
FuelHopper375 had the same output for LiquidFuel as FielHopper250. Raised Ratio by about 2.5 (Same as LiquidFuel part of LF-OX receipt)