### PR TITLE
Bugfix for #1508

### DIFF
--- a/Source/WOLF/WOLF/Modules/WOLF_HopperModule.cs
+++ b/Source/WOLF/WOLF/Modules/WOLF_HopperModule.cs
@@ -73,7 +73,8 @@ namespace WOLF
                 Messenger.DisplayMessage(Messenger.MISSING_DEPOT_MESSAGE);
                 return;
             }
-            var otherDepotModules = vessel.FindPartModulesImplementing<WOLF_DepotModule>();
+            var otherDepotModules = vessel.FindPartModulesImplementing<WOLF_DepotModule>()
+                .Where(p => !(p is WOLF_SurveyModule));
             if (otherDepotModules.Any())
             {
                 Messenger.DisplayMessage(Messenger.INVALID_DEPOT_PART_ATTACHMENT_MESSAGE);

--- a/Source/WOLF/WOLF/Modules/WOLF_HopperModule.cs
+++ b/Source/WOLF/WOLF/Modules/WOLF_HopperModule.cs
@@ -188,6 +188,16 @@ namespace WOLF
 
             ParseWolfRecipe();
 
+            if (IsConnectedToDepot)
+            {
+                // Hook into vessel destroyed event to release resources back to depot
+                if (vessel != null)
+                {
+                    vessel.OnJustAboutToBeDestroyed += OnVesselDestroyed;
+                    GameEvents.OnVesselRecoveryRequested.Add(OnVesselRecovered);
+                }
+            }
+
             // CurrentBiome is used in VerifyDepotConnection
             CurrentBiome = WOLF_AbstractPartModule.GetVesselBiome(vessel);
             VerifyDepotConnection();


### PR DESCRIPTION
# Description
**Closes Issues in #1508**
- If a vessel with a running hopper is moved outside biome hopper wil still run
- If trying to connect a hopper to depot and WOLF-SurveyModule is on vessel a message saying "Depots must be detached" is shown
# How to test / reproduce
 - Launch a hopper
 - Connect it to depot
 - Move vessel outside current WOLF-Biome
 	- 	=> Hopper still connected to depot
