### PR TITLE
Fix: updated CrewContainer375.cfg to have correct module name...

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_375.cfg
@@ -56,7 +56,7 @@ PART
 
 	MODULE
 	{
-		name = WOLF_CargoModule
+		name = WOLF_CrewCargoModule
 		EconomyBerths = 14
 		LuxuryBerths = 7
 		ModuleName = #LOC_USI_WOLF_CrewCargoModuleName


### PR DESCRIPTION
…to allow part to act as crew transporter with correct values in-game (as opposed to cargo transporter with default value).
Tested on local machine and fix appears to work as intended (part displays correct crew-related values on hover-over after fix).