### PR TITLE
Moved tech tree locations of wolf parts for balance

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Patches/WOLF_CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Patches/WOLF_CTT.cfg
@@ -5,12 +5,12 @@
 
 @PART[WOLF_Depot]:NEEDS[CommunityTechTree]
 {
-	@TechRequired = logistics
+	@TechRequired = advLogistics
 }
 
 @PART[WOLF_Drill_01]:NEEDS[CommunityTechTree]
 {
-	@TechRequired = advScienceTech
+	@TechRequired = resourceExploitation
 }
 
 @PART[WOLF_Drill_02]:NEEDS[CommunityTechTree]
@@ -40,9 +40,8 @@
 
 @PART[WOLF_HarvestingHopper375]:NEEDS[CommunityTechTree]
 {
-	@TechRequired = advScienceTech
+	@TechRequired = advLogistics
 }
-
 
 @PART[WOLF_LifeSupportHopper375]:NEEDS[CommunityTechTree]
 {
@@ -54,9 +53,53 @@
 	@TechRequired = advColonization
 }
 
+@PART[WOLF_FuelHopper250]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advLogistics
+}
+@PART[WOLF_HarvestingHopper250]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advLogistics
+}
+	
+@PART[WOLF_LifeSupportHopper250]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advLogistics
+}
+
+@PART[WOLF_ManufacturingHopper250]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advLogistics
+}
+
+@PART[WOLF_HarvestingHopper375]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advColonization
+}
+
+@PART[WOLF_BioreactorModule375]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advColonization
+}
+
+@PART[WOLF_WasteProcessor375]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advColonization
+}
+
 @PART[WOLF_LifeSupport375]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = advColonization
+}
+
+@PART[WOLF_Harvester_125]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advOffworldMining
+}
+
+@PART[WOLF_Harvester_375]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = resourceExploitation
 }
 
 @PART[WOLF_MaintenanceModule375]:NEEDS[CommunityTechTree]
@@ -86,7 +129,7 @@
 
 @PART[WOLF_Transporter]:NEEDS[CommunityTechTree]
 {
-	@TechRequired = logistics
+	@TechRequired = advlogistics
 }
 
 @PART[WOLF_TransportModule375]:NEEDS[CommunityTechTree]


### PR DESCRIPTION
Moved WOLF depots, 275 hoppers and transporter to advLogistics, the 275 WOLF harvesters to advOffwordMining  and 375 WOLF harvesters to resourceexploitation.