### PR TITLE
Add CrewCapacity to Orbital Shipyard 250

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_500.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Konstruction/Parts/Konstruction_Orbital_Shipyard_500.cfg
@@ -37,6 +37,7 @@ PART
 	breakingTorque= 2000
 	maxTemp = 1200 // = 2900
 	bulkheadProfiles = size3
+	CrewCapacity = 1
 
 	MODULE
 	{


### PR DESCRIPTION
added CrewCapacity = 1 to cfg to allow engineer to be in structure for the Konstruction module to give bonus.