### PR TITLE
Fixes reputation loss from dying Kerbals during Depot-connecting

### DIFF
--- a/Source/WOLF/WOLF/Poof.cs
+++ b/Source/WOLF/WOLF/Poof.cs
@@ -48,7 +48,7 @@ namespace WOLF
                 var endingReputation = Reputation.Instance.reputation;
                 if (endingReputation + 0.0001f < startingReputation)
                 {
-                    Reputation.Instance.AddReputation(startingReputation - endingReputation, TransactionReasons.None);
+                    Reputation.Instance.SetReputation(startingReputation, TransactionReasons.None);
                 }
             }
         }


### PR DESCRIPTION
Currently there is a significant reputation-loss incurred, when depositing Kerbals to Wolf-Depots.
This is caused by diminishing reputation gain and is more visible when the reputation is high.

The previous method for adjusting the reputation loss for dying Kerbals does not take the diminishing reputation gain into account. This patch fixes this problem by using "SetReputation" instead of "AddReputation".