### PR TITLE
Adjust EVA scrapping range for a few very large parts

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/ScrapParts.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/ScrapParts.cfg
@@ -8,6 +8,33 @@
 	Efficiency = .5
   }
 }
+
+// The default EVARange of 5m is not large enough to be able to scrap the following parts
+// USI MKS Atlas 20m Factory, Farm and Kerbitat
+@PART[Atlas_*_20m]
+{
+  @MODULE[USI_ModuleRecycleablePart]
+  {
+    EVARange = 7.5
+  }
+}
+// Kontainer Tank - Round (11m)
+@PART[C3_RTank_06]
+{
+  @MODULE[USI_ModuleRecycleablePart]
+  {
+    EVARange = 7
+  }
+}
+// Kontainer Tank - Round (15m)
+@PART[C3_RTank_08]
+{
+  @MODULE[USI_ModuleRecycleablePart]
+  {
+    EVARange = 8.5
+  }
+}
+
 @PART[PotatoRoid]
 {
   @MODULE[USI_ModuleRecycleablePart]


### PR DESCRIPTION
Some parts are too big and can currently not be scrapped while in EVA.

This patch adjusts the EVARange for these parts so that they can also be scrapped.