### PR TITLE
Fix an exception during connecting to depot with complex ships

### DIFF
--- a/Source/WOLF/WOLF/Poof.cs
+++ b/Source/WOLF/WOLF/Poof.cs
@@ -27,9 +27,11 @@ namespace WOLF
                 //https://kerbalspaceprogram.com/api/class_fine_print_1_1_utilities_1_1_system_utilities.html#afd1eea0118d0c37dacd3ea696b125ff2
                 SystemUtilities.ExpungeKerbal(kerbal);
             }
-            foreach (var part in vessel.parts.ToArray())
+
+            var parts = vessel.parts.ToArray();
+            for (var i = parts.Length - 1; i >= 0; i--)
             {
-                part.Die();
+                parts[i].Die();
             }
 
             vessel.Die();


### PR DESCRIPTION
For more complex vessels I experienced the strange behavior, that during connection to a depot, only parts of the ship were destroyed and other parts left as debris in place. This also had the effect that I lost reputation from all the killed Kerbals. The logs showed the following exception:

```
[EXC 00:22:33.184] NullReferenceException: Object reference not set to an instance of an object
	ModuleStructuralNode.CheckDisplay () (at <4deecb19beb547f19b1ff89b4c59bd84>:0)
	ModuleStructuralNode.DecoupleAction (System.String nodeName, System.Boolean weDecouple) (at <4deecb19beb547f19b1ff89b4c59bd84>:0)
	Part.Decoupling (System.Single breakForce) (at <4deecb19beb547f19b1ff89b4c59bd84>:0)
	(wrapper dynamic-method) Part.Part.decouple_Patch2(Part,single)
	(wrapper dynamic-method) Part.Part.Die_Patch2(Part)
	WOLF.Poof.GoPoof (Vessel vessel) (at <c31a380b8bdc4e1a9e3dc235d6d7f1c6>:0)
	WOLF.WOLF_ConverterModule.ConnectToDepot () (at <c31a380b8bdc4e1a9e3dc235d6d7f1c6>:0)
	WOLF.WOLF_AbstractPartModule.ConnectToDepotEvent () (at <c31a380b8bdc4e1a9e3dc235d6d7f1c6>:0)
	BaseEvent.Invoke () (at <4deecb19beb547f19b1ff89b4c59bd84>:0)
	UIPartActionButton.OnClick () (at <4deecb19beb547f19b1ff89b4c59bd84>:0)
	UnityEngine.Events.InvokableCall.Invoke () (at <2425394cf09642369e2109953e31f62b>:0)
	UnityEngine.Events.UnityEvent.Invoke () (at <2425394cf09642369e2109953e31f62b>:0)
	UnityEngine.UI.Button.Press () (at <e15fd066925c43a8a8f645414da73acb>:0)
	UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) (at <e15fd066925c43a8a8f645414da73acb>:0)
	UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) (at <e15fd066925c43a8a8f645414da73acb>:0)
	UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor) (at <e15fd066925c43a8a8f645414da73acb>:0)
	UnityEngine.DebugLogHandler:LogException(Exception, Object)
	ModuleManager.UnityLogHandle.InterceptLogHandler:LogException(Exception, Object)
	UnityEngine.EventSystems.EventSystem:Update()
```

I was able to prevent this exception by reversing the order, in which parts get deleted. Currently the parts get deleted beginning with the root-part. This patch changes this so that the root part is deleted last.

Rationale: It seems like deleting a part with multiple children creates several distinct vessels before continuing to delete the other parts.