### PR TITLE
Fix inconsistency between editor and flight behavior regarding Wolf depot creation

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Localization/en-us.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Localization/en-us.cfg
@@ -67,6 +67,7 @@ Localization
         #autoLOC_USI_WOLF_ESTABLISH_DEPOT_GUI_NAME = Establish depot
         #autoLOC_USI_WOLF_NO_DEPOTS_ESTABLISHED_MESSAGE = There are currently no established depots.
         #autoLOC_USI_WOLF_SURVEY_GUI_NAME = Survey WOLF Biome
+        #autoLOC_USI_WOLF_CONVERTERS_ABANDONED_DURING_DEPOT_CREATION_MESSAGE = Converter Modules abandoned during depot creation.
 
         // Converter messages
         #autoLOC_USI_WOLF_NEEDS = Needs


### PR DESCRIPTION
In the editor it is perfectly fine to attach a Wolf Depot and a Wolf Converter to the same ship.

However when one tries to establish a depot with such a vessel, one receives a message, that these parts can not be on the same ship.

There seem to be two solutions:
- Change the behavior of the editor
- Change the behavior during Depot-creation

This PR is a first step for implementing the second option.

This patch changes the behavior of Depot-creation in the following way:
- allow Wolf-converters to be on the ship
- allow Crew to be on the ship
- after creating the depot, establish the converters and the crew to the Biome
- in the case that the planning was incorrect, the converters get abandoned (*)

The this patch aims to leave the previous behavior for connecting converters the same.

(*) I am not quite happy with this behavior, but lack currently an idea for how to do this better. So I will leave this PR as a draft for the moment.