### PR TITLE
Fix attachment nodes becoming unusable in editor after undo

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_CargoBay.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_CargoBay.cfg
@@ -12,7 +12,7 @@ PART
 	node_stack_innerT = 0.0, 0.0, 0.86, 0.0, 0.0, -1.0,1
 	node_stack_innerB = 0.0, 0.0, -.86, 0.0, 0.0, 1.0,1
 	node_stack_innerL = 0.0, 1.2, 0.0, 0.0, -1.0, 0.0,1
-	node_stack_inner_R  = 0.0, -1.2, 0.0, 0.0, 1.0, 0.0,1
+	node_stack_innerR  = 0.0, -1.2, 0.0, 0.0, 1.0, 0.0,1
 
 	node_stack_topHatch = 0.0, 1.5, 0.4, 0.0, 1.0, 0.0,1
 	node_stack_bottomHatch = 0.0, -1.5, 0.4, 0.0, -1.0, 0.0,1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Hub.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Hub.cfg
@@ -8,18 +8,18 @@ PART
 		model = UmbraSpaceIndustries/Karibou/Assets/KER_Hub
 	}
 	rescaleFactor = 1
-	node_stack_cargo_FL = 0.35,1.285,-0.6625,0,-1,0,0
-	node_stack_cargo_FR = -0.35,1.285,-0.6625,0,-1,0,0
-	node_stack_cargo_RL = 0.35,-1.285,-0.6625,0,1,0,0
-	node_stack_cargo_RR = -0.35,-1.285,-0.6625,0,1,0,0
+	node_stack_cargoFL = 0.35,1.285,-0.6625,0,-1,0,0
+	node_stack_cargoFR = -0.35,1.285,-0.6625,0,-1,0,0
+	node_stack_cargoRL = 0.35,-1.285,-0.6625,0,1,0,0
+	node_stack_cargoRR = -0.35,-1.285,-0.6625,0,1,0,0
 
 	node_stack_rack = 0.0, 0.0, -0.3, 0.0, 0.0, -1.0,1
-	node_stack_rack_fore = 0.0, 0.84, -0.3, 0.0, 0.0, -1.0,0
-	node_stack_rack_aft = 0.0, -0.84, -0.3, 0.0, 0.0, -1.0,0
+	node_stack_rackfore = 0.0, 0.84, -0.3, 0.0, 0.0, -1.0,0
+	node_stack_rackaft = 0.0, -0.84, -0.3, 0.0, 0.0, -1.0,0
 
 	node_stack_roof = 0.0, 0.0, -1.025, 0.0, 0.0, -1.0,1
-	node_stack_roof_fore = 0.0, 0.84, -1.025, 0.0, 0.0, -1.0,0
-	node_stack_roof_aft = 0.0, -0.84, -1.025, 0.0, 0.0, -1.0,0
+	node_stack_rooffore = 0.0, 0.84, -1.025, 0.0, 0.0, -1.0,0
+	node_stack_roofaft = 0.0, -0.84, -1.025, 0.0, 0.0, -1.0,0
 	
 	node_stack_top2 = 0.0, 1.285, .4, 0.0, 1.0, 0.0,1
 	node_stack_bottom2 = 0.0, -1.285,.4, 0.0, -1.0, 0.0,1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Agriculture.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Agriculture.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Bioreactor.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Bioreactor.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CargoKontainer_125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CargoKontainer_125.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CargoKontainer_250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CargoKontainer_250.cfg
@@ -18,9 +18,9 @@ PART
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	 0.0, 0.0,-1.0,		 0, 0,-1,	2
-	node_stack_side_1 =	 0.0, 0.0, 1.0,		 0, 0, 1,	2
-	node_stack_side_2 =	-1.0, 0.0, 0.0,		-1, 0, 0,	2
-	node_stack_side_4 =	 1.0, 0.0, 0.0,		 1, 0, 0,	2
+	node_stack_side1 =	 0.0, 0.0, 1.0,		 0, 0, 1,	2
+	node_stack_side2 =	-1.0, 0.0, 0.0,		-1, 0, 0,	2
+	node_stack_side4 =	 1.0, 0.0, 0.0,		 1, 0, 0,	2
 	node_attach = 0,0,-1,0,0,1,2
 	node_stack_top = 0.0, 2, 0.0, 0.0, 1.0, 0.0, 2
 	node_stack_bottom = 0, -2, 0.0, 0.0, -1.0, 0.0, 2

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CargoKontainer_375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CargoKontainer_375.cfg
@@ -18,9 +18,9 @@ PART
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	 0.0, 0.0,-1.5,		 0, 0,-1,	3
-	node_stack_side_1 =	 0.0, 0.0, 1.5,		 0, 0, 1,	3
-	node_stack_side_2 =	-1.5, 0.0, 0.0,		-1, 0, 0,	3
-	node_stack_side_4 =	 1.5, 0.0, 0.0,		 1, 0, 0,	3
+	node_stack_side1 =	 0.0, 0.0, 1.5,		 0, 0, 1,	3
+	node_stack_side2 =	-1.5, 0.0, 0.0,		-1, 0, 0,	3
+	node_stack_side4 =	 1.5, 0.0, 0.0,		 1, 0, 0,	3
 	node_attach = 0,0,-1.5,0,0,1,3
 	node_stack_top = 0.0, 3, 0.0, 0.0, 1.0, 0.0, 3
 	node_stack_bottom = 0, -3, 0.0, 0.0, -1.0, 0.0, 3

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CargoKontainer_500.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CargoKontainer_500.cfg
@@ -18,9 +18,9 @@ PART
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	 0.0, 0.0,-2.0,		 0, 0,-1,	3
-	node_stack_side_1 =	 0.0, 0.0, 2.0,		 0, 0, 1,	3
-	node_stack_side_2 =	-2.0, 0.0, 0.0,		-1, 0, 0,	3
-	node_stack_side_4 =	 2.0, 0.0, 0.0,		 1, 0, 0,	3
+	node_stack_side1 =	 0.0, 0.0, 2.0,		 0, 0, 1,	3
+	node_stack_side2 =	-2.0, 0.0, 0.0,		-1, 0, 0,	3
+	node_stack_side4 =	 2.0, 0.0, 0.0,		 1, 0, 0,	3
 	node_attach = 0,0,-2,0,0,1,3
 	node_stack_top = 0.0, 4, 0.0, 0.0, 1.0, 0.0, 3
 	node_stack_bottom = 0, -4, 0.0, 0.0, -1.0, 0.0, 3

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_125.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_250.cfg
@@ -18,9 +18,9 @@ PART
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	 0.0, 0.0,-1.0,		 0, 0,-1,	2
-	node_stack_side_1 =	 0.0, 0.0, 1.0,		 0, 0, 1,	2
-	node_stack_side_2 =	-1.0, 0.0, 0.0,		-1, 0, 0,	2
-	node_stack_side_4 =	 1.0, 0.0, 0.0,		 1, 0, 0,	2
+	node_stack_side1 =	 0.0, 0.0, 1.0,		 0, 0, 1,	2
+	node_stack_side2 =	-1.0, 0.0, 0.0,		-1, 0, 0,	2
+	node_stack_side4 =	 1.0, 0.0, 0.0,		 1, 0, 0,	2
 	node_attach = 0,0,-1,0,0,1,2
 	node_stack_top = 0.0, 2, 0.0, 0.0, 1.0, 0.0, 2
 	node_stack_bottom = 0, -2, 0.0, 0.0, -1.0, 0.0, 2

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_375.cfg
@@ -18,9 +18,9 @@ PART
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	 0.0, 0.0,-1.5,		 0, 0,-1,	3
-	node_stack_side_1 =	 0.0, 0.0, 1.5,		 0, 0, 1,	3
-	node_stack_side_2 =	-1.5, 0.0, 0.0,		-1, 0, 0,	3
-	node_stack_side_4 =	 1.5, 0.0, 0.0,		 1, 0, 0,	3
+	node_stack_side1 =	 0.0, 0.0, 1.5,		 0, 0, 1,	3
+	node_stack_side2 =	-1.5, 0.0, 0.0,		-1, 0, 0,	3
+	node_stack_side4 =	 1.5, 0.0, 0.0,		 1, 0, 0,	3
 	node_attach = 0,0,-1.5,0,0,1,3
 	node_stack_top = 0.0, 3, 0.0, 0.0, 1.0, 0.0, 3
 	node_stack_bottom = 0, -3, 0.0, 0.0, -1.0, 0.0, 3

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_500.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/CrewCargoKontainer_500.cfg
@@ -18,9 +18,9 @@ PART
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	 0.0, 0.0,-2.0,		 0, 0,-1,	3
-	node_stack_side_1 =	 0.0, 0.0, 2.0,		 0, 0, 1,	3
-	node_stack_side_2 =	-2.0, 0.0, 0.0,		-1, 0, 0,	3
-	node_stack_side_4 =	 2.0, 0.0, 0.0,		 1, 0, 0,	3
+	node_stack_side1 =	 0.0, 0.0, 2.0,		 0, 0, 1,	3
+	node_stack_side2 =	-2.0, 0.0, 0.0,		-1, 0, 0,	3
+	node_stack_side4 =	 2.0, 0.0, 0.0,		 1, 0, 0,	3
 	node_attach = 0,0,-2,0,0,1,3
 	node_stack_top = 0.0, 4, 0.0, 0.0, 1.0, 0.0, 3
 	node_stack_bottom = 0, -4, 0.0, 0.0, -1.0, 0.0, 3

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Depot.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Depot.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Extractor.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Extractor.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Fabricator.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Fabricator.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Habitation.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Habitation.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Harvester_125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Harvester_125.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Harvester_375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Harvester_375.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/LifeSupport.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/LifeSupport.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/MaintenanceModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/MaintenanceModule.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/PowerModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/PowerModule.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Refinery.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/Refinery.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/ScienceModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/ScienceModule.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/TransportModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/TransportModule.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/WasteProcessor.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WOLF/Parts/WasteProcessor.cfg
@@ -13,9 +13,9 @@ PART
 
 	// node definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
-	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
-	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
-	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
+	node_stack_side1 =	   0,  0,  0.5,  0,  0,  1, 1
+	node_stack_side2 =	-0.5,  0,    0, -1,  0,  0, 1
+	node_stack_side4 =	 0.5,  0,    0,  1,  0,  0, 1
 	node_attach       =    0,  0, -0.5,  0,  0,  1, 1
 	node_stack_top    =    0,  1,    0,  0,  1,  0, 1
 	node_stack_bottom =    0, -1,    0,  0, -1,  0, 1


### PR DESCRIPTION
fix #1571

The attach nodes of Wolf Cargo Containers are defined like this:

```
	node_stack_side   =	   0,  0, -0.5,  0,  0, -1, 1
	node_stack_side_1 =	   0,  0,  0.5,  0,  0,  1, 1
	node_stack_side_2 =	-0.5,  0,    0, -1,  0,  0, 1
	node_stack_side_4 =	 0.5,  0,    0,  1,  0,  0, 1
```

However after attaching parts to each of the side nodes, they get saved in the .craft file as:

```
	attN = side,advSasModule_4294251462_0|0|-0.5_0|0|-1_0|0|-0.5_0|0|-1
	attN = side,advSasModule_4294251836_0|0|0.5_0|0|1_0|0|0.5_0|0|1
	attN = side,advSasModule_4294251088_-0.5|0|0_-1|0|0_-0.5|0|0_-1|0|0
	attN = side,advSasModule_4294250716_0.5|0|0_1|0|0_0.5|0|0_1|0|0
```

This indicates that all 4 attached parts are attached to the same attach node "node_stack_side"

Also in the save game, the Wolf Cargo Container looks like this:

```
	srfN = srfAttach, -1
	attN = side, -1
	attN = side, -1
	attN = side, -1
	attN = side, -1
	attN = top, 0
	attN = bottom, -1
```

This indicates four times, that the attach node "node_stack_side" has no part "-1" attached to it but says nothing about the other three attach nodes.

My conclusion is, that the node_stack definitions are parsed in a strange way when more than two underscores "_" appear in the definition.

This PR changes the definitions by removing the third underscore.

I can't tell for sure, if this change makes problems for existing savegames, so I would appreciate it, if someone with more experience could verify, if this is a breaking change.