### PR TITLE
Fix #1559 KAribou wheels uncontrollable

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Wheel_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Wheel_01.cfg
@@ -45,11 +45,21 @@ PART
 
 		// setting this to true will override the radius and center parameters
 		FitWheelColliderToMesh = False
-		radius = 0.45
+		useNewFrictionModel = true
+		wheelType = MOTORIZED
+		adherentStart = 0.5
+		frictionAdherent = .3
+		peakStart = 3
+		frictionPeak = 1.5
+		limitStart = 6
+		frictionLimit = 1.3		
+		// setting this to true will override the radius and center parameters
+		FitWheelColliderToMesh = False		
+		radius = 0.5
 		center = 0,0,0
 		mass = 0.040
 		groundHeightOffset = 0
-
+				
 		TooltipTitle = Rover Wheel
 		TooltipPrimaryField = Motorized
 	}
@@ -58,7 +68,7 @@ PART
 		name = ModuleWheelSuspension
 		baseModuleIndex = 0
 		suspensionTransformName = suspensionPivot
-
+		maximumLoad = 40.0	
 		suspensionDistance = 0.125
 		targetPosition = 0.5
 		springRatio = 7
@@ -67,15 +77,25 @@ PART
 	MODULE
 	{
 		name = ModuleWheelSteering
-		baseModuleIndex = 0
-		caliperTransformName = SteeringPivot
-		steeringResponse = 2
+		baseModuleIndex = 0	
+		caliperTransformName = SteeringPivot		
+		autoSteeringAdjust = true
+		steeringResponse = 1.5
+		
+		steeringRange = 35
+		
 		steeringCurve
 		{
 			key = 0 20
-			key = 1 5
-			key = 10 2.5
-			key = 30 0.25
+			key = 20 20
+		}
+		steeringMaxAngleCurve
+		{
+			key = 0 1 0 0
+			key = 3 1 0.0001624425 0.0001624425
+			key = 7.5 0.33 -0.05674612 -0.05674612
+			key = 20 0.12 -0.003158088 -0.003158088
+			key = 30 0.1 -0.002872917 -0.002872917
 		}
 	}
 	MODULE
@@ -138,5 +158,8 @@ PART
 		useStandInCollider = True
 		slaveModules = 8
 	}
+
+}
+
 
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Wheel_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Wheel_01.cfg
@@ -53,8 +53,6 @@ PART
 		frictionPeak = 1.5
 		limitStart = 6
 		frictionLimit = 1.3		
-		// setting this to true will override the radius and center parameters
-		FitWheelColliderToMesh = False		
 		radius = 0.5
 		center = 0,0,0
 		mass = 0.040


### PR DESCRIPTION
fix UmbraSpaceIndustries/MKS#1559
karibou wheels started behaving strangely at least since KSP 1.12.2. This patch brings them close to Malemute large wheel and actually working state.

tested in KSP 1.12.4