### PR TITLE
Update MKS_EL_Parts.cfg - EL Parts deletion

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/PatchManager/PluginData/MKS_EL_Parts.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/MKS/Patches/PatchManager/PluginData/MKS_EL_Parts.cfg
@@ -1,25 +1,40 @@
-//remove needless EL parts
-//config by theRagingIrishman
+//Removes all parts from Extraplanetary Launchpad except for the mallet and survey stake.
+//config by theRagingIrishman updated by Rocket_Bob
 
 !PART[ELTank*MTL]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 !PART[ELTank*ORE]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 !PART[ELTank*RP]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELTank*SCRAP]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 
-!PART[Auger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[SmallAuger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[TinyAuger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELAuger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELSmallAuger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELTinyAuger]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 
 !PART[HexCanMetal*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 !PART[HexCanOre*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 !PART[HexCanRocketParts*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 !PART[Rocketparts*7x]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 
-!PART[Magnetometer]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[OMD]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELMagnetometer]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELOMD]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 
-!PART[RocketBuilder]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELRocketBuilder]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 
-!PART[Smelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[SmallSmelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}
-!PART[TinySmelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELSmelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELSmallSmelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELTinySmelter]:NEEDS[Launchpad]:AFTER[Launchpad] {}
 
+!PART[ELLathe]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELControlReference]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+
+!PART[ELConstructionDrone*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELRecycleBin*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+
+!PART[ELRunway]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELLaunchpad*]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELLandingPad]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELOrbitalDock]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELRocketBuilder]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+
+!PART[ELWorkshop]:NEEDS[Launchpad]:AFTER[Launchpad] {}
+!PART[ELMicroPad]:NEEDS[Launchpad]:AFTER[Launchpad] {}


### PR DESCRIPTION
Updated theRagingIrishman's config since most EL parts have been renamed (prefixed with EL). Deleted most other parts too since MKS makes the recycling functionality redundant and has its own parts with EL modules.
It would perhaps be wiser to simply hide these parts instead. Let me know.